### PR TITLE
Added additional types to PropertyType

### DIFF
--- a/zio-config/src/main/scala/zio/config/PropertyType.scala
+++ b/zio-config/src/main/scala/zio/config/PropertyType.scala
@@ -23,25 +23,18 @@ object PropertyType extends AttemptSyntax {
     override def write(a: String): String                       = a
   }
 
-  case object IntType extends PropertyType[Int] {
-    def description: String = "value of type int"
-    def read(value: String): Either[ErrorType, Int] =
-      value.toInt.attempt(_ => ParseError(value, "int"))
-    def write(value: Int): String = value.toString
+  case object BooleanType extends PropertyType[Boolean] {
+    def description: String = "value of type boolean"
+    def read(value: String): Either[ErrorType, Boolean] =
+      value.toBoolean.attempt(_ => ParseError(value, "boolean"))
+    def write(value: Boolean): String = value.toString
   }
 
-  case object UriType extends PropertyType[URI] {
-    def description: String = "value of type uri"
-    def read(value: String): Either[ErrorType, URI] =
-      new URI(value).attempt(_ => ParseError(value, "uri"))
-    def write(value: URI): String = value.toString
-  }
-
-  case object LongType extends PropertyType[Long] {
-    def description: String = "value of type long"
-    def read(value: String): Either[ErrorType, Long] =
-      value.toLong.attempt(_ => ParseError(value, "long"))
-    def write(value: Long): String = value.toString
+  case object ByteType extends PropertyType[Byte] {
+    def description: String = "value of type byte"
+    def read(value: String): Either[ErrorType, Byte] =
+      value.toByte.attempt(_ => ParseError(value, "byte"))
+    def write(value: Byte): String = value.toString
   }
 
   case object ShortType extends PropertyType[Short] {
@@ -51,11 +44,53 @@ object PropertyType extends AttemptSyntax {
     def write(value: Short): String = value.toString
   }
 
+  case object IntType extends PropertyType[Int] {
+    def description: String = "value of type int"
+    def read(value: String): Either[ErrorType, Int] =
+      value.toInt.attempt(_ => ParseError(value, "int"))
+    def write(value: Int): String = value.toString
+  }
+
+  case object LongType extends PropertyType[Long] {
+    def description: String = "value of type long"
+    def read(value: String): Either[ErrorType, Long] =
+      value.toLong.attempt(_ => ParseError(value, "long"))
+    def write(value: Long): String = value.toString
+  }
+
+  case object BigIntType extends PropertyType[BigInt] {
+    def description: String = "value of type bigint"
+    def read(value: String): Either[ErrorType, BigInt] =
+      BigInt(value).attempt(_ => ParseError(value, "bigint"))
+    def write(value: BigInt): String = value.toString
+  }
+
+  case object FloatType extends PropertyType[Float] {
+    def description: String = "value of type float"
+    def read(value: String): Either[ErrorType, Float] =
+      value.toFloat.attempt(_ => ParseError(value, "float"))
+    def write(value: Float): String = value.toString
+  }
+
   case object DoubleType extends PropertyType[Double] {
     def description: String = "value of type double"
     def read(value: String): Either[ErrorType, Double] =
       value.toDouble.attempt(_ => ParseError(value, "double"))
     def write(value: Double): String = value.toString
+  }
+
+  case object BigDecimalType extends PropertyType[BigDecimal] {
+    def description: String = "value of type bigdecimal"
+    def read(value: String): Either[ErrorType, BigDecimal] =
+      BigDecimal(value).attempt(_ => ParseError(value, "bigdecimal"))
+    def write(value: BigDecimal): String = value.toString
+  }
+
+  case object UriType extends PropertyType[URI] {
+    def description: String = "value of type uri"
+    def read(value: String): Either[ErrorType, URI] =
+      new URI(value).attempt(_ => ParseError(value, "uri"))
+    def write(value: URI): String = value.toString
   }
 
   private[config] def ofOption[A](propertyType: PropertyType[A]): PropertyType[Option[A]] =

--- a/zio-config/src/main/scala/zio/config/package.scala
+++ b/zio-config/src/main/scala/zio/config/package.scala
@@ -5,12 +5,17 @@ import java.net.URI
 import zio.config.actions.{ Read, Report, Write }
 
 package object config extends Sources {
-  def int(path: String): Config[Int]       = Config.Source(path, PropertyType.IntType)
-  def double(path: String): Config[Double] = Config.Source(path, PropertyType.DoubleType)
-  def string(path: String): Config[String] = Config.Source(path, PropertyType.StringType)
-  def long(path: String): Config[Long]     = Config.Source(path, PropertyType.LongType)
-  def short(path: String): Config[Short]   = Config.Source(path, PropertyType.ShortType)
-  def uri(path: String): Config[URI]       = Config.Source(path, PropertyType.UriType)
+  def string(path: String): Config[String]         = Config.Source(path, PropertyType.StringType)
+  def boolean(path: String): Config[Boolean]       = Config.Source(path, PropertyType.BooleanType)
+  def byte(path: String): Config[Byte]             = Config.Source(path, PropertyType.ByteType)
+  def short(path: String): Config[Short]           = Config.Source(path, PropertyType.ShortType)
+  def int(path: String): Config[Int]               = Config.Source(path, PropertyType.IntType)
+  def long(path: String): Config[Long]             = Config.Source(path, PropertyType.LongType)
+  def bigInt(path: String): Config[BigInt]         = Config.Source(path, PropertyType.BigIntType)
+  def float(path: String): Config[Float]           = Config.Source(path, PropertyType.FloatType)
+  def double(path: String): Config[Double]         = Config.Source(path, PropertyType.DoubleType)
+  def bigDecimal(path: String): Config[BigDecimal] = Config.Source(path, PropertyType.BigDecimalType)
+  def uri(path: String): Config[URI]               = Config.Source(path, PropertyType.UriType)
 
   def opt[A](config: => Config[A]): Config[Option[A]] =
     config


### PR DESCRIPTION
I have added support for additional numeric types as well as boolean values. There are a few things that should be considered-
* do we wish to use the `override` keyword (as has been used for `StringType`)?
* do we wish to have case insensitive boolean values? Currently, the `toBoolean` method is used which is case insensitive.

```
scala> "TRue".toBoolean
res0: Boolean = true
```

I believe we could also consider adding `Option` and `List` to the ADT-
```
  case class OptionType[A](propertyType: PropertyType[A]) extends PropertyType[Option[A]] {
    def description: String = s"optional ${propertyType.description}"
    def read(value: String): Either[ErrorType, Option[A]] =
      if (value.isEmpty) Right(None)
      else propertyType.read(value).map(Some(_))
    def write(value: Option[A]): String = value.fold("")(propertyType.write)
  }
```