### PR TITLE
Use System to access env and properties

### DIFF
--- a/examples/src/main/scala/zio/config/examples/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/CoproductExample.scala
@@ -63,7 +63,7 @@ object CoproductExample extends App {
     runtime.unsafeRun(read(prodOrDev).provide(invalidSource).either) ==
       Left(
         List(
-          MissingValue("x1"),
+          MissingValue("x1", "Key not in map"),
           ParseError("x5", "notadouble", "double")
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
+++ b/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
@@ -22,8 +22,8 @@ object ErrorAccumulation extends App {
     parsed ==
       Left(
         List(
-          MissingValue("envvar"),
-          MissingValue("envvar2")
+          MissingValue("envvar", "Key not in map"),
+          MissingValue("envvar2", "Key not in map")
         )
       )
   )
@@ -41,7 +41,7 @@ object ErrorAccumulation extends App {
       Left(
         List(
           ParseError("envvar", "wrong", "int"),
-          MissingValue("envvar2")
+          MissingValue("envvar2", "Key not in map")
         )
       )
   )

--- a/zio-config/src/main/scala/zio/config/Config.scala
+++ b/zio-config/src/main/scala/zio/config/Config.scala
@@ -3,7 +3,8 @@ package zio.config
 import java.net.URI
 
 import zio.config.actions.Read
-import zio.{ system, IO, Task, UIO, ZIO }
+import zio.system.System
+import zio.{ IO, RIO, UIO, ZIO }
 
 trait Config[A] {
   def config: Config.Service[A]
@@ -31,20 +32,20 @@ object Config {
     override def config: UIO[A] = ZIO.succeed(a)
   }
 
-  def fromEnv[A](configDescriptor: ConfigDescriptor[A]): ZIO[system.System, Throwable, Config[A]] =
+  def fromEnv[A](configDescriptor: ConfigDescriptor[A]): RIO[System, Config[A]] =
     for {
-      lineSep <- ZIO.accessM[zio.system.System](sys => sys.system.lineSeparator)
-      source  <- Task(sys.env).map(mapSource)
+      lineSep <- ZIO.accessM[System](_.system.lineSeparator)
+      source  <- envSource
       res     <- make(source, configDescriptor).mapError(t => new RuntimeException(t.mkString(lineSep)))
     } yield res
 
   def fromMap[A](map: Map[String, String], configDescriptor: ConfigDescriptor[A]): IO[ReadErrors, Config[A]] =
     make(mapSource(map), configDescriptor)
 
-  def fromPropertyFile[A](configDescriptor: ConfigDescriptor[A]): ZIO[system.System, Throwable, Config[A]] =
+  def fromPropertyFile[A](configDescriptor: ConfigDescriptor[A]): RIO[System, Config[A]] =
     for {
-      lineSep <- ZIO.accessM[zio.system.System](sys => sys.system.lineSeparator)
-      source  <- Task(sys.props.toMap).map(mapSource)
+      lineSep <- ZIO.accessM[System](_.system.lineSeparator)
+      source  <- propSource
       res     <- make(source, configDescriptor).mapError(t => new RuntimeException(t.mkString(lineSep)))
     } yield res
 

--- a/zio-config/src/main/scala/zio/config/ConfigSource.scala
+++ b/zio-config/src/main/scala/zio/config/ConfigSource.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.IO
+import zio.Task
 
 trait ConfigSource {
   val configService: ConfigSource.Service
@@ -8,6 +8,6 @@ trait ConfigSource {
 
 object ConfigSource {
   trait Service {
-    def getConfigValue(path: String): IO[Unit, String]
+    def getConfigValue(path: String): Task[String]
   }
 }

--- a/zio-config/src/main/scala/zio/config/ConfigSource.scala
+++ b/zio-config/src/main/scala/zio/config/ConfigSource.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.Task
+import zio.IO
 
 trait ConfigSource {
   val configService: ConfigSource.Service
@@ -8,6 +8,6 @@ trait ConfigSource {
 
 object ConfigSource {
   trait Service {
-    def getConfigValue(path: String): Task[String]
+    def getConfigValue(path: String): IO[ReadError, String]
   }
 }

--- a/zio-config/src/main/scala/zio/config/ReadError.scala
+++ b/zio-config/src/main/scala/zio/config/ReadError.scala
@@ -5,6 +5,7 @@ sealed trait ReadError {
 }
 
 object ReadError {
-  case class MissingValue(key: String)                                 extends ReadError
-  case class ParseError(key: String, provided: String, `type`: String) extends ReadError
+  final case class MissingValue(key: String, cause: String)                  extends ReadError
+  final case class ParseError(key: String, provided: String, `type`: String) extends ReadError
+  final case class FatalError(key: String, cause: Throwable)                 extends ReadError
 }

--- a/zio-config/src/main/scala/zio/config/Sources.scala
+++ b/zio-config/src/main/scala/zio/config/Sources.scala
@@ -1,17 +1,39 @@
 package zio.config
 
-import zio.{ IO, Task }
+import zio.system.System
+import zio.{ Task, ZIO }
 
 trait Sources {
-  def envSource: Task[ConfigSource] =
-    Task(sys.env).map(mapSource)
+  def envSource: ZIO[System, Throwable, ConfigSource] =
+    ZIO.access { env =>
+      new ConfigSource {
+        val configService: ConfigSource.Service =
+          (path: String) =>
+            env.system.env(path).flatMap { (oStr: Option[String]) =>
+              oStr.fold[Task[String]](
+                ZIO.fail(new IllegalArgumentException(s"Not defined in system environment: $path"))
+              )(ZIO.succeed)
+            }
+      }
+    }
 
-  def propSource: Task[ConfigSource] =
-    Task(sys.props.toMap).map(mapSource)
+  def propSource: ZIO[System, Throwable, ConfigSource] =
+    ZIO.access { env =>
+      new ConfigSource {
+        val configService: ConfigSource.Service =
+          (path: String) =>
+            env.system.property(path).flatMap { (oStr: Option[String]) =>
+              oStr.fold[Task[String]](
+                ZIO.fail(new IllegalArgumentException(s"System property not found for key: $path"))
+              )(ZIO.succeed)
+            }
+      }
+    }
 
   def mapSource(map: Map[String, String]): ConfigSource =
     new ConfigSource {
-      val configService: ConfigSource.Service = (path: String) => IO.fromOption(map.get(path))
+      val configService: ConfigSource.Service =
+        (path: String) => ZIO.effect(map(path))
     }
 
   // TODO HOCON etc as separate modules

--- a/zio-config/src/main/scala/zio/config/actions/Read.scala
+++ b/zio-config/src/main/scala/zio/config/actions/Read.scala
@@ -1,6 +1,5 @@
 package zio.config.actions
 
-import zio.config.ReadError.MissingValue
 import zio.config.ReadErrors
 import zio.config.{ ConfigDescriptor }
 import zio.config.{ ConfigReport, ConfigSource, Details }
@@ -21,7 +20,7 @@ object Read {
           for {
             value <- config
                       .getConfigValue(path)
-                      .mapError(_ => ReadErrors(MissingValue(path)))
+                      .mapError(err => ReadErrors(err))
             r <- report
                   .update(_.addDetails(Details(path, value, previousDescription)))
             result <- ZIO.fromEither(

--- a/zio-config/src/main/scala/zio/config/package.scala
+++ b/zio-config/src/main/scala/zio/config/package.scala
@@ -11,7 +11,7 @@ package object config extends Sources {
 
   def config[A]: ZIO[Config[A], Nothing, A] = ZIO.accessM(_.config.config)
 
-  def getConfigValue(path: String): RIO[ConfigSource, String] =
+  def getConfigValue(path: String): ZIO[ConfigSource, ReadError, String] =
     ZIO.accessM(_.configService.getConfigValue(path))
 
   type ReadErrors = ::[ReadError]

--- a/zio-config/src/main/scala/zio/config/package.scala
+++ b/zio-config/src/main/scala/zio/config/package.scala
@@ -11,7 +11,8 @@ package object config extends Sources {
 
   def config[A]: ZIO[Config[A], Nothing, A] = ZIO.accessM(_.config.config)
 
-  def getConfigValue(path: String): ZIO[ConfigSource, Unit, String] = ZIO.accessM(_.configService.getConfigValue(path))
+  def getConfigValue(path: String): RIO[ConfigSource, String] =
+    ZIO.accessM(_.configService.getConfigValue(path))
 
   type ReadErrors = ::[ReadError]
 

--- a/zio-config/src/test/scala/zio/config/CoproductTest.scala
+++ b/zio-config/src/test/scala/zio/config/CoproductTest.scala
@@ -50,7 +50,7 @@ object CoproductTest extends Properties("Coproduct support") with TestSupport {
     readWithErrors(p).shouldBe {
       Left(
         ReadErrors(
-          MissingValue(p.kLdap),
+          MissingValue(p.kLdap, "Key not in map"),
           ParseError(p.kFactor, "notadouble", "double")
         )
       )

--- a/zio-config/src/test/scala/zio/config/ReadErrorsTest.scala
+++ b/zio-config/src/test/scala/zio/config/ReadErrorsTest.scala
@@ -15,7 +15,7 @@ object ReadErrorsTest extends Properties("ReadErrors/NEL") with TestSupport {
     } yield ParseError(s1, s2, s3)
 
   private val genReadError: Gen[ReadError] =
-    Gen.oneOf(Gen.const(MissingValue("somekey")), genParseError)
+    Gen.oneOf(Gen.const(MissingValue("somekey", "Key not in map")), genParseError)
 
   private val genReadErrors: Gen[List[ReadError]] =
     for {


### PR DESCRIPTION
In this pull request, `System` is used to access environment variables and system properties.

Note: this may be advantageous since `... even if the security manager does not permit the getProperties operation, it may choose to permit the getProperty(String) operation.` Also, this change should improve testability via environmental effects.