### PR TITLE
Use lineSeparator defined in package object system

### DIFF
--- a/zio-config/src/main/scala/zio/config/Config.scala
+++ b/zio-config/src/main/scala/zio/config/Config.scala
@@ -2,7 +2,7 @@ package zio.config
 
 import java.net.URI
 import zio.config.actions.Read
-import zio.system.System
+import zio.system._
 import zio.{ IO, RIO, UIO, ZIO }
 
 trait Config[A] {
@@ -28,7 +28,7 @@ object Config {
 
   def fromEnv[A](configDescriptor: ConfigDescriptor[A]): RIO[System, Config[A]] =
     for {
-      lineSep <- ZIO.accessM[System](_.system.lineSeparator)
+      lineSep <- lineSeparator
       source  <- envSource
       res     <- make(source, configDescriptor).mapError(t => new RuntimeException(t.mkString(lineSep)))
     } yield res
@@ -38,7 +38,7 @@ object Config {
 
   def fromPropertyFile[A](configDescriptor: ConfigDescriptor[A]): RIO[System, Config[A]] =
     for {
-      lineSep <- ZIO.accessM[System](_.system.lineSeparator)
+      lineSep <- lineSeparator
       source  <- propSource
       res     <- make(source, configDescriptor).mapError(t => new RuntimeException(t.mkString(lineSep)))
     } yield res


### PR DESCRIPTION
Pretty minor change, we can use `lineSeparator` defined in the `system` package object -
https://github.com/zio/zio/blob/06d3257a2a58aed7721c0de2b0422f27f07fd491/core/shared/src/main/scala-2.12%2B/zio/system.scala