### PR TITLE
Fix toString for error types and fix ErrorAccumulation example

### DIFF
--- a/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
+++ b/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
@@ -39,7 +39,7 @@ object ErrorAccumulation extends App {
   assert(
     runtime.unsafeRun(read(config).provide(invalidSource).either) ==
       Left(
-        List(
+        ReadErrors(
           ParseError("envvar", "wrong", "int"),
           MissingValue("envvar2")
         )

--- a/zio-config/src/main/scala/zio/config/ReadErrors.scala
+++ b/zio-config/src/main/scala/zio/config/ReadErrors.scala
@@ -4,7 +4,9 @@ import zio.config.ReadErrors.ReadError
 
 import scala.util.control.NoStackTrace
 
-final case class ReadErrors[K, V](errors: ::[ReadError[K, V]]) extends NoStackTrace
+final case class ReadErrors[K, V](errors: ::[ReadError[K, V]]) extends NoStackTrace {
+  override def toString(): String = s"ReadErrors($errors)"
+}
 
 object ReadErrors {
   def apply[K, V](a: ReadError[K, V], as: ReadError[K, V]*): ReadErrors[K, V] =
@@ -18,9 +20,14 @@ object ReadErrors {
   }
 
   object ReadError {
-    final case class MissingValue[K](key: K)                                extends ReadError[K, Nothing]
-    final case class ParseError[K, V](key: K, provided: V, message: String) extends ReadError[K, V]
-    final case class FatalError[K](key: K, cause: Throwable)                extends ReadError[K, Nothing]
+    final case class MissingValue[K](key: K) extends ReadError[K, Nothing] {
+      override def toString(): String = s"MissingValue($key)"
+    }
+    final case class ParseError[K, V](key: K, provided: V, message: String) extends ReadError[K, V] {
+      override def toString(): String = s"ParseError($key, $provided, $message)"
+    }
+    final case class FatalError[K](key: K, cause: Throwable) extends ReadError[K, Nothing] {
+      override def toString(): String = s"FatalError($key, $cause)"
+    }
   }
-
 }

--- a/zio-config/src/main/scala/zio/config/ReadErrors.scala
+++ b/zio-config/src/main/scala/zio/config/ReadErrors.scala
@@ -15,19 +15,20 @@ object ReadErrors {
   def concat[K, V](l: ReadErrors[K, V], r: ReadErrors[K, V]): ReadErrors[K, V] =
     ReadErrors(::(l.errors.head, l.errors.tail ++ r.errors))
 
-  sealed trait ReadError[+K, +V] extends NoStackTrace {
+  sealed trait ReadError[+K, +V] extends NoStackTrace { self =>
     val key: K
+
+    override def toString(): String = self match {
+      case ReadError.MissingValue(key)                  => s"MissingValue($key)"
+      case ReadError.ParseError(key, provided, message) => s"ParseError($key, $provided, $message)"
+      case ReadError.FatalError(key, cause)             => s"FatalError($key, $cause)"
+    }
   }
 
   object ReadError {
-    final case class MissingValue[K](key: K) extends ReadError[K, Nothing] {
-      override def toString(): String = s"MissingValue($key)"
-    }
-    final case class ParseError[K, V](key: K, provided: V, message: String) extends ReadError[K, V] {
-      override def toString(): String = s"ParseError($key, $provided, $message)"
-    }
-    final case class FatalError[K](key: K, cause: Throwable) extends ReadError[K, Nothing] {
-      override def toString(): String = s"FatalError($key, $cause)"
-    }
+    final case class MissingValue[K](key: K)                                extends ReadError[K, Nothing]
+    final case class ParseError[K, V](key: K, provided: V, message: String) extends ReadError[K, V]
+    final case class FatalError[K](key: K, cause: Throwable)                extends ReadError[K, Nothing]
   }
+
 }


### PR DESCRIPTION
Unfortunately, `NoStackTrace` breaks the `toString` representation of case classes. This PR fixes this issue. There was also a failing test in the examples which is fixed here