### PR TITLE
Add duration type

### DIFF
--- a/zio-config/src/main/scala/zio/config/ConfigDescriptor.scala
+++ b/zio-config/src/main/scala/zio/config/ConfigDescriptor.scala
@@ -1,5 +1,7 @@
 package zio.config
 
+import scala.concurrent.duration.Duration
+
 import java.net.URI
 import zio.config.ConfigDescriptor.Default
 import zio.config.ConfigDescriptor.OrElseEither
@@ -157,6 +159,8 @@ object ConfigDescriptor {
     ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigDecimalType) ? "value of type bigdecimal"
   def uri(path: String): ConfigDescriptor[String, String, URI] =
     ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.UriType) ? "value of type uri"
+  def duration(path: String): ConfigDescriptor[String, String, Duration] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DurationType) ? "value of type duration"
   def nested[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
     ConfigDescriptor.Nested(desc, path)
 }

--- a/zio-config/src/main/scala/zio/config/PropertyType.scala
+++ b/zio-config/src/main/scala/zio/config/PropertyType.scala
@@ -4,6 +4,7 @@ import java.net.URI
 
 import zio.config.PropertyType.PropertyReadError
 
+import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success, Try }
 
 trait PropertyType[V, A] {
@@ -77,6 +78,12 @@ object PropertyType {
     def read(value: String): Either[PropertyReadError[String], URI] =
       attempt(new URI(value), _ => PropertyReadError(value, "uri"))
     def write(value: URI): String = value.toString
+  }
+
+  case object DurationType extends PropertyType[String, Duration] {
+    def read(value: String): Either[PropertyReadError[String], Duration] =
+      attempt(Duration.apply(value), _ => PropertyReadError(value, "duration"))
+    def write(value: Duration): String = value.toString
   }
 
   private def attempt[A, E](a: => A, f: Throwable => E): Either[E, A] =

--- a/zio-config/src/test/scala/zio/config/helpers.scala
+++ b/zio-config/src/test/scala/zio/config/helpers.scala
@@ -14,7 +14,14 @@ object helpers {
       s <- Gen.listOfN(n)(Gen.alphaNumericChar)
     } yield s.mkString
 
+  def genNumber(min: Int, max: Int): Gen[Random, Int] =
+    for {
+      n <- Gen.int(min, max)
+    } yield n
+
   def genNonEmptyString(length: Int): Gen[Random, String] = genSymbol(1, length)
+
+  def genDuration(length: Int): Gen[Random, String] = genNumber(1, length).map(days => s"$days day")
 
   val genId: Gen[Random, Id] = genSymbol(1, 5).map(Id)
 


### PR DESCRIPTION
Add duration data type. Some configs use `scala.concurrent.duration.Duration` to define timeouts, time a token is valid, etc. on their configuration files.