### PR TITLE
Remove redundant UIO wrappers around returned configuration etc

### DIFF
--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -4,15 +4,15 @@ import java.io.{ File, FileInputStream }
 import java.util.Properties
 
 import zio.system.System
-import zio.{ IO, Task, UIO, ZIO }
 import zio.system.System.Live.system.lineSeparator
+import zio.{ IO, Task, ZIO }
 
 trait Config[A] { self =>
   def config: Config.Service[A]
 }
 object Config {
   trait Service[A] {
-    def config: UIO[A]
+    def config: A
   }
 
   def make[K, V, A](
@@ -23,9 +23,10 @@ object Config {
       .map(
         e =>
           new Config[A] {
-            override def config: Service[A] = new Service[A] {
-              override def config: UIO[A] = ZIO.succeed(e)
-            }
+            override def config: Service[A] =
+              new Service[A] {
+                override def config: A = e
+              }
           }
       )
 

--- a/core/src/main/scala/zio/config/package.scala
+++ b/core/src/main/scala/zio/config/package.scala
@@ -5,7 +5,7 @@ package object config extends ReadFunctions with WriteFunctions with ConfigDocsF
   final type ReadErrorsVector[K, V] = ReadErrors[Vector[K], V]
 
   final def config[A]: ZIO[Config[A], Nothing, A] =
-    ZIO.accessM(_.config.config)
+    ZIO.access(_.config.config)
 
   private[config] def concat[A](l: ::[A], r: ::[A]): ::[A] =
     ::(l.head, l.tail ++ r)

--- a/docs/refined/index.md
+++ b/docs/refined/index.md
@@ -40,9 +40,9 @@ val myAppLogic: ZIO[RefinedProd, Nothing, Refined[List[Long], Size[Greater[W.`2`
 
 val configMultiMap =
   Map(
-    "LDAP"     -> singleton("ldap"),
-    "PORT"     -> singleton("1999"),
-    "DB_URL"   -> singleton("ddd"),
+    "LDAP"     -> ::("ldap", Nil),
+    "PORT"     -> ::("1999", Nil),
+    "DB_URL"   -> ::("ddd", Nil),
     "LONGVALS" -> ::("1234", List("2345", "3456"))
   )
   

--- a/docs/refined/index.md
+++ b/docs/refined/index.md
@@ -4,7 +4,7 @@ title:  "Automatic Validations"
 ---
 
 By bringing in `zio-config-refined` module, you get validations for your config parameters almost for free. 
-`zio-config` elegantly integrates with `Refined` library for you to ahieve this with same ergnomics!
+`zio-config` elegantly integrates with `Refined` library for you to achieve this with same ergnomics!
 
 ```scala mdoc:silent
 
@@ -24,49 +24,33 @@ case class RefinedProd(
   longs: Refined[List[Long], Size[Greater[W.`2`.T]]]
 )
 
-def prodConfig(n: Int): ConfigDescriptor[String, String, RefinedProd] =
+def prodConfig: ConfigDescriptor[String, String, RefinedProd] =
   (
     nonEmpty(string("LDAP")) |@|
       greaterEqual[W.`1024`.T](int("PORT")) |@|
       nonEmpty(string("DB_URL")).optional |@|
-      size[Greater[W.`2`.T]](longs(n).xmap(_.toList)(list => ::(list.head, list.tail)))
+      size[Greater[W.`2`.T]](list(long("LONGVALS")))
   )(
     RefinedProd.apply,
     RefinedProd.unapply
   )
 
-def longList(n: Int): List[ConfigDescriptor[String, String, Long]] =
-  (1 to n).toList
-    .map(group => long(s"GROUP${group}_LONGVAL"))
+val myAppLogic: ZIO[RefinedProd, Nothing, Refined[List[Long], Size[Greater[W.`2`.T]]]] =
+  ZIO.access[RefinedProd](_.longs)
 
-def longs(n: Int): ConfigDescriptor[String, String, ::[Long]] =
-  ConfigDescriptor.collectAll[String, String, Long](::(longList(n).head, longList(n).tail))
-
-val myAppLogic: ZIO[Config[RefinedProd], Nothing, Refined[List[Long], Size[Greater[W.`2`.T]]]] =
-  for {
-    prod <- config[RefinedProd]
-  } yield prod.longs
-
-val configMap =
+val configMultiMap =
   Map(
-    "LDAP"           -> "ldap",
-    "PORT"           -> "1999",
-    "DB_URL"         -> "ddd",
-    "COUNT"          -> "3",
-    "GROUP1_LONGVAL" -> "1234",
-    "GROUP2_LONGVAL" -> "2345",
-    "GROUP3_LONGVAL" -> "3456"
+    "LDAP"     -> singleton("ldap"),
+    "PORT"     -> singleton("1999"),
+    "DB_URL"   -> singleton("ddd"),
+    "LONGVALS" -> ::("1234", List("2345", "3456"))
   )
   
-val outcome =
+val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =
   for {
-    count  <- Config.fromMap(configMap, nonNegative(int("COUNT")))
-    n      <- count.config.config
-    config <- Config.fromMap(configMap, prodConfig(n.value))
+    config <- read(prodConfig.from(ConfigSource.fromMultiMap(configMultiMap)))
     r      <- myAppLogic.provide(config)
   } yield r
-  
-
 ```
 
-Checkout examples for usage of `zio-config-refined` in examples module of the project.
+Check out sample usage of `zio-config-refined` in `examples` module of the project.

--- a/examples/src/main/scala/zio/config/examples/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/RefinedReadConfig.scala
@@ -55,7 +55,7 @@ object RefinedReadConfig extends App {
       val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =
         for {
           count  <- Config.fromMap(configMap, nonNegative(int("COUNT")))
-          n      <- count.config.config
+          n      = count.config.config
           config <- Config.fromMap(configMap, prodConfig(n.value))
           r      <- myAppLogic.provide(config)
         } yield r

--- a/examples/src/main/scala/zio/config/examples/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/RefinedReadConfig.scala
@@ -35,9 +35,9 @@ object RefinedReadConfig extends App {
     ZIO.accessM { env =>
       val configMultiMap =
         Map(
-          "LDAP"     -> singleton("ldap"),
-          "PORT"     -> singleton("1999"),
-          "DB_URL"   -> singleton("ddd"),
+          "LDAP"     -> ::("ldap", Nil),
+          "PORT"     -> ::("1999", Nil),
+          "DB_URL"   -> ::("ddd", Nil),
           "LONGVALS" -> ::("1234", List("2345", "3456"))
         )
       val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =


### PR DESCRIPTION
Updating the pattern of instantiating program startup-time shared objects (like configuration and the hypothetical Spark session in the program example)