### PR TITLE
Restructured examples / Added Examples to Coproduct.

### DIFF
--- a/examples/src/main/scala/zio/config/examples/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/CoproductExample.scala
@@ -2,7 +2,7 @@ package zio.config.examples
 
 import zio.DefaultRuntime
 import zio.config.ConfigDescriptor._
-import zio.config.{read, _}
+import zio.config.{ read, _ }
 
 // see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
 object CoproductExample extends App {

--- a/examples/src/main/scala/zio/config/examples/magnolia/AutomaticConfigDescExample.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/AutomaticConfigDescExample.scala
@@ -1,10 +1,10 @@
-package zio.config.examples
+package zio.config.examples.magnolia
 
 import zio.ZIO
 import zio.config.ConfigSource
+import zio.config.examples.magnolia.MyConfig._
 import zio.config.magnolia.ConfigDescriptorProvider._
 import zio.console.Console.Live.console._
-import MyConfig._
 
 final case class MyConfig(
   aws: Aws,

--- a/examples/src/main/scala/zio/config/examples/magnolia/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/CoproductExample.scala
@@ -2,7 +2,7 @@ package zio.config.examples.magnolia
 
 import zio.DefaultRuntime
 import zio.config.magnolia.ConfigDescriptorProvider.description
-import zio.config.{ConfigSource, read, singleton, write}
+import zio.config.{ read, singleton, write, ConfigSource }
 
 object CoproductExample extends App {
 

--- a/examples/src/main/scala/zio/config/examples/magnolia/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/CoproductExample.scala
@@ -1,10 +1,9 @@
-package zio.config.examples
+package zio.config.examples.magnolia
 
 import zio.DefaultRuntime
-import zio.config.ConfigDescriptor._
-import zio.config.{read, _}
+import zio.config.magnolia.ConfigDescriptorProvider.description
+import zio.config.{ConfigSource, read, singleton, write}
 
-// see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
 object CoproductExample extends App {
 
   sealed trait Dance
@@ -16,43 +15,7 @@ object CoproductExample extends App {
   final case class Person(name: String, age: Option[Int])
   final case class Height(height: Long)
 
-  val personConfig =
-    (string("name") |@| int("age").optional)(Person.apply, Person.unapply)
-
-  val heightConfig =
-    long("height").xmap(Height)(_.height)
-
-  val aConfig = nested("any")(personConfig).xmap(A)(_.any)
-  val bConfig = nested("body")(heightConfig).xmap(B)(_.body)
-  val cConfig = boolean("can").xmap(C)(_.can)
-  val dConfig = string("dance").xmap(D)(_.dance)
-
-  val aConfigAsDance =
-    aConfig.xmapEither(a => Right(a: Dance))({
-      case a: A => Right(a)
-      case _    => Left("unable to write back")
-    })
-
-  val bConfigAsDance =
-    bConfig.xmapEither(a => Right(a: Dance))({
-      case a: B => Right(a)
-      case _    => Left("unsable to write back")
-    })
-
-  val cConfigAsDance =
-    cConfig.xmapEither(a => Right(a: Dance))({
-      case a: C => Right(a)
-      case _    => Left("unsable to write back")
-    })
-
-  val dConigAsDance =
-    dConfig.xmapEither(a => Right(a: Dance))({
-      case a: D => Right(a)
-      case _    => Left("unsable to write back")
-    })
-
-  val danceConfig =
-    aConfigAsDance.orElse(bConfigAsDance).orElse(cConfigAsDance).orElse(dConigAsDance)
+  val danceConfig = description[Dance]
 
   val aSource = ConfigSource.fromMap(
     Map(

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -2,12 +2,12 @@ package zio.config.examples.refined
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.{NonEmpty, Size}
-import eu.timepit.refined.numeric.{Greater, GreaterEqual}
-import zio.config.ConfigDescriptor.{int, list, long, string}
-import zio.config.refined.{greaterEqual, nonEmpty, size}
-import zio.config.{ConfigDescriptor, ConfigSource, ReadErrors, read}
-import zio.{App, ZIO, ZEnv}
+import eu.timepit.refined.collection.{ NonEmpty, Size }
+import eu.timepit.refined.numeric.{ Greater, GreaterEqual }
+import zio.config.ConfigDescriptor.{ int, list, long, string }
+import zio.config.refined.{ greaterEqual, nonEmpty, size }
+import zio.config.{ read, ConfigDescriptor, ConfigSource, ReadErrors }
+import zio.{ App, ZEnv, ZIO }
 
 object RefinedReadConfig extends App {
   case class RefinedProd(

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -1,13 +1,13 @@
-package zio.config.examples
+package zio.config.examples.refined
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection._
-import eu.timepit.refined.numeric._
-import zio.config.ConfigDescriptor._
-import zio.config._
-import zio.config.refined._
-import zio.{ App, ZEnv, ZIO }
+import eu.timepit.refined.collection.{NonEmpty, Size}
+import eu.timepit.refined.numeric.{Greater, GreaterEqual}
+import zio.config.ConfigDescriptor.{int, list, long, string}
+import zio.config.refined.{greaterEqual, nonEmpty, size}
+import zio.config.{ConfigDescriptor, ConfigSource, ReadErrors, read}
+import zio.{App, ZIO, ZEnv}
 
 object RefinedReadConfig extends App {
   case class RefinedProd(

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductAutomaticExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductAutomaticExample.scala
@@ -1,0 +1,90 @@
+package zio.config.examples.typesafe
+
+import zio.DefaultRuntime
+import zio.config.magnolia.ConfigDescriptorProvider.description
+import zio.config.typesafe.TypeSafeConfigSource.hocon
+import zio.config.{read, _}
+
+// see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
+object CoproductAutomaticExample extends App {
+
+  sealed trait Dance
+
+  case class A(any: Person) extends Dance
+
+  case class B(body: Height) extends Dance
+
+  case class C(can: Boolean) extends Dance
+
+  case class D(dance: String) extends Dance
+
+  final case class Person(name: String, age: Option[Int])
+
+  final case class Height(height: Long)
+
+  val danceConfig = description[Dance]
+
+  val aSource = hocon(Right(
+    "any.name = chris"
+  ))
+
+  val bSource = hocon(Right(
+    "body.height = 179"
+  ))
+
+  val cSource = hocon(Right(
+    "can = false"
+  ))
+
+  val dSource = hocon(Right(
+    """dance = "I am Dancing !!""""
+  ))
+
+  val runtime = new DefaultRuntime {}
+
+  def readA =
+    runtime.unsafeRun(
+      read(danceConfig from aSource)
+    )
+
+  def readB =
+    runtime.unsafeRun(
+      read(danceConfig from bSource)
+    )
+
+  def readC =
+    runtime.unsafeRun(
+      read(danceConfig from cSource)
+    )
+
+  def readD =
+    runtime.unsafeRun(
+      read(danceConfig from dSource)
+    )
+
+  assert(
+    readA == A(Person("chris", None)) &&
+      readB == B(Height(179)) &&
+      readC == C(false) &&
+      readD == D("I am Dancing !!")
+  )
+
+  val writeA =
+    write(danceConfig, readA).map(_.flattenString())
+
+  val writeB =
+    write(danceConfig, readB).map(_.flattenString())
+
+  val writeC =
+    write(danceConfig, readC).map(_.flattenString())
+
+  val writeD =
+    write(danceConfig, readD).map(_.flattenString())
+
+  assert(
+    writeA == Right(Map("any.name" -> singleton("chris"))) &&
+      writeB == Right(Map("body.height" -> singleton("179"))) &&
+      writeC == Right(Map("can" -> singleton("false"))) &&
+      writeD == Right(Map("dance" -> singleton("I am Dancing !!")))
+  )
+}

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductAutomaticExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductAutomaticExample.scala
@@ -3,7 +3,7 @@ package zio.config.examples.typesafe
 import zio.DefaultRuntime
 import zio.config.magnolia.ConfigDescriptorProvider.description
 import zio.config.typesafe.TypeSafeConfigSource.hocon
-import zio.config.{read, _}
+import zio.config.{ read, _ }
 
 // see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
 object CoproductAutomaticExample extends App {
@@ -24,21 +24,29 @@ object CoproductAutomaticExample extends App {
 
   val danceConfig = description[Dance]
 
-  val aSource = hocon(Right(
-    "any.name = chris"
-  ))
+  val aSource = hocon(
+    Right(
+      "any.name = chris"
+    )
+  )
 
-  val bSource = hocon(Right(
-    "body.height = 179"
-  ))
+  val bSource = hocon(
+    Right(
+      "body.height = 179"
+    )
+  )
 
-  val cSource = hocon(Right(
-    "can = false"
-  ))
+  val cSource = hocon(
+    Right(
+      "can = false"
+    )
+  )
 
-  val dSource = hocon(Right(
-    """dance = "I am Dancing !!""""
-  ))
+  val dSource = hocon(
+    Right(
+      """dance = "I am Dancing !!""""
+    )
+  )
 
   val runtime = new DefaultRuntime {}
 
@@ -82,9 +90,9 @@ object CoproductAutomaticExample extends App {
     write(danceConfig, readD).map(_.flattenString())
 
   assert(
-    writeA == Right(Map("any.name" -> singleton("chris"))) &&
+    writeA == Right(Map("any.name"      -> singleton("chris"))) &&
       writeB == Right(Map("body.height" -> singleton("179"))) &&
-      writeC == Right(Map("can" -> singleton("false"))) &&
-      writeD == Right(Map("dance" -> singleton("I am Dancing !!")))
+      writeC == Right(Map("can"         -> singleton("false"))) &&
+      writeD == Right(Map("dance"       -> singleton("I am Dancing !!")))
   )
 }

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductExample.scala
@@ -1,23 +1,29 @@
-package zio.config.examples
+package zio.config.examples.typesafe
 
 import zio.DefaultRuntime
 import zio.config.ConfigDescriptor._
+import zio.config.typesafe.TypeSafeConfigSource.hocon
 import zio.config.{read, _}
 
 // see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
 object CoproductExample extends App {
 
   sealed trait Dance
-  case class A(any: Person)   extends Dance
-  case class B(body: Height)  extends Dance
-  case class C(can: Boolean)  extends Dance
+
+  case class A(any: Person) extends Dance
+
+  case class B(body: Height) extends Dance
+
+  case class C(can: Boolean) extends Dance
+
   case class D(dance: String) extends Dance
 
   final case class Person(name: String, age: Option[Int])
+
   final case class Height(height: Long)
 
   val personConfig =
-    (string("name") |@| int("age").optional)(Person.apply, Person.unapply)
+    (string("name") |@| int("age").optional) (Person.apply, Person.unapply)
 
   val heightConfig =
     long("height").xmap(Height)(_.height)
@@ -30,53 +36,45 @@ object CoproductExample extends App {
   val aConfigAsDance =
     aConfig.xmapEither(a => Right(a: Dance))({
       case a: A => Right(a)
-      case _    => Left("unable to write back")
+      case _ => Left("unable to write back")
     })
 
   val bConfigAsDance =
     bConfig.xmapEither(a => Right(a: Dance))({
       case a: B => Right(a)
-      case _    => Left("unsable to write back")
+      case _ => Left("unsable to write back")
     })
 
   val cConfigAsDance =
     cConfig.xmapEither(a => Right(a: Dance))({
       case a: C => Right(a)
-      case _    => Left("unsable to write back")
+      case _ => Left("unsable to write back")
     })
 
   val dConigAsDance =
     dConfig.xmapEither(a => Right(a: Dance))({
       case a: D => Right(a)
-      case _    => Left("unsable to write back")
+      case _ => Left("unsable to write back")
     })
 
   val danceConfig =
     aConfigAsDance.orElse(bConfigAsDance).orElse(cConfigAsDance).orElse(dConigAsDance)
 
-  val aSource = ConfigSource.fromMap(
-    Map(
-      "any.name" -> "chris"
-    )
-  )
+  val aSource = hocon(Right(
+    "any.name = chris"
+  ))
 
-  val bSource = ConfigSource.fromMap(
-    Map(
-      "body.height" -> "179"
-    )
-  )
+  val bSource = hocon(Right(
+    "body.height = 179"
+  ))
 
-  val cSource = ConfigSource.fromMap(
-    Map(
-      "can" -> "false"
-    )
-  )
+  val cSource = hocon(Right(
+    "can = false"
+  ))
 
-  val dSource = ConfigSource.fromMap(
-    Map(
-      "dance" -> "I am Dancing !!"
-    )
-  )
+  val dSource = hocon(Right(
+    """dance = "I am Dancing !!""""
+  ))
 
   val runtime = new DefaultRuntime {}
 
@@ -120,9 +118,9 @@ object CoproductExample extends App {
     write(danceConfig, readD).map(_.flattenString())
 
   assert(
-    writeA == Right(Map("any.name"      -> singleton("chris"))) &&
+    writeA == Right(Map("any.name" -> singleton("chris"))) &&
       writeB == Right(Map("body.height" -> singleton("179"))) &&
-      writeC == Right(Map("can"         -> singleton("false"))) &&
-      writeD == Right(Map("dance"       -> singleton("I am Dancing !!")))
+      writeC == Right(Map("can" -> singleton("false"))) &&
+      writeD == Right(Map("dance" -> singleton("I am Dancing !!")))
   )
 }

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductExample.scala
@@ -3,7 +3,7 @@ package zio.config.examples.typesafe
 import zio.DefaultRuntime
 import zio.config.ConfigDescriptor._
 import zio.config.typesafe.TypeSafeConfigSource.hocon
-import zio.config.{read, _}
+import zio.config.{ read, _ }
 
 // see Stackoverflow: https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config
 object CoproductExample extends App {
@@ -23,7 +23,7 @@ object CoproductExample extends App {
   final case class Height(height: Long)
 
   val personConfig =
-    (string("name") |@| int("age").optional) (Person.apply, Person.unapply)
+    (string("name") |@| int("age").optional)(Person.apply, Person.unapply)
 
   val heightConfig =
     long("height").xmap(Height)(_.height)
@@ -36,45 +36,53 @@ object CoproductExample extends App {
   val aConfigAsDance =
     aConfig.xmapEither(a => Right(a: Dance))({
       case a: A => Right(a)
-      case _ => Left("unable to write back")
+      case _    => Left("unable to write back")
     })
 
   val bConfigAsDance =
     bConfig.xmapEither(a => Right(a: Dance))({
       case a: B => Right(a)
-      case _ => Left("unsable to write back")
+      case _    => Left("unsable to write back")
     })
 
   val cConfigAsDance =
     cConfig.xmapEither(a => Right(a: Dance))({
       case a: C => Right(a)
-      case _ => Left("unsable to write back")
+      case _    => Left("unsable to write back")
     })
 
   val dConigAsDance =
     dConfig.xmapEither(a => Right(a: Dance))({
       case a: D => Right(a)
-      case _ => Left("unsable to write back")
+      case _    => Left("unsable to write back")
     })
 
   val danceConfig =
     aConfigAsDance.orElse(bConfigAsDance).orElse(cConfigAsDance).orElse(dConigAsDance)
 
-  val aSource = hocon(Right(
-    "any.name = chris"
-  ))
+  val aSource = hocon(
+    Right(
+      "any.name = chris"
+    )
+  )
 
-  val bSource = hocon(Right(
-    "body.height = 179"
-  ))
+  val bSource = hocon(
+    Right(
+      "body.height = 179"
+    )
+  )
 
-  val cSource = hocon(Right(
-    "can = false"
-  ))
+  val cSource = hocon(
+    Right(
+      "can = false"
+    )
+  )
 
-  val dSource = hocon(Right(
-    """dance = "I am Dancing !!""""
-  ))
+  val dSource = hocon(
+    Right(
+      """dance = "I am Dancing !!""""
+    )
+  )
 
   val runtime = new DefaultRuntime {}
 
@@ -118,9 +126,9 @@ object CoproductExample extends App {
     write(danceConfig, readD).map(_.flattenString())
 
   assert(
-    writeA == Right(Map("any.name" -> singleton("chris"))) &&
+    writeA == Right(Map("any.name"      -> singleton("chris"))) &&
       writeB == Right(Map("body.height" -> singleton("179"))) &&
-      writeC == Right(Map("can" -> singleton("false"))) &&
-      writeD == Right(Map("dance" -> singleton("I am Dancing !!")))
+      writeC == Right(Map("can"         -> singleton("false"))) &&
+      writeD == Right(Map("dance"       -> singleton("I am Dancing !!")))
   )
 }

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconExample.scala
@@ -1,7 +1,7 @@
 package zio.config.examples.typesafe
 
 import zio.DefaultRuntime
-import zio.config.ConfigDescriptor.{int, list, nested, string}
+import zio.config.ConfigDescriptor.{ int, list, nested, string }
 import zio.config.magnolia.ConfigDescriptorProvider.description
 import zio.config.read
 import zio.config.typesafe.TypeSafeConfigSource.hocon

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconExample.scala
@@ -1,9 +1,10 @@
-package zio.config.examples
+package zio.config.examples.typesafe
 
-import zio.config.typesafe.TypeSafeConfigSource._
-import zio.config._, ConfigDescriptor._
 import zio.DefaultRuntime
-import zio.config.magnolia.ConfigDescriptorProvider._
+import zio.config.ConfigDescriptor.{int, list, nested, string}
+import zio.config.magnolia.ConfigDescriptorProvider.description
+import zio.config.read
+import zio.config.typesafe.TypeSafeConfigSource.hocon
 
 object TypesafeConfigHoconExample extends App {
   val runtime = new DefaultRuntime {}

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconList.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconList.scala
@@ -1,7 +1,7 @@
 package zio.config.examples.typesafe
 
 import zio.DefaultRuntime
-import zio.config.ConfigDescriptor.{int, list, nested, string}
+import zio.config.ConfigDescriptor.{ int, list, nested, string }
 import zio.config.magnolia.ConfigDescriptorProvider.description
 import zio.config.read
 import zio.config.typesafe.TypeSafeConfigSource.hocon

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconList.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigHoconList.scala
@@ -1,9 +1,10 @@
-package zio.config.examples
+package zio.config.examples.typesafe
 
-import zio.config.typesafe.TypeSafeConfigSource._
-import zio.config._, ConfigDescriptor._
 import zio.DefaultRuntime
-import zio.config.magnolia.ConfigDescriptorProvider._
+import zio.config.ConfigDescriptor.{int, list, nested, string}
+import zio.config.magnolia.ConfigDescriptorProvider.description
+import zio.config.read
+import zio.config.typesafe.TypeSafeConfigSource.hocon
 
 object TypesafeConfigHoconList extends App {
   val runtime = new DefaultRuntime {}


### PR DESCRIPTION
On the proposal to add examples by Afsal Thaj - see https://stackoverflow.com/questions/59670366/how-to-handle-an-adt-sealed-trait-with-zio-config

I added two other CoproductExamples:

* manual
* typesafe

I only made examples for the 2. Version, as the first one did not appeal to me;).

That there was no name clash and as there are now quite a lot examples, I introduced the structure analog to the submodules.

I saw that IntelliJ restructured the imports a bit, I hope this is not a problem.