### PR TITLE
Update ZIO to 1.0.0-RC18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ createProductBuilder := {
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-lazy val zioVersion      = "1.0.0-RC17"
+lazy val zioVersion      = "1.0.0-RC18"
 lazy val magnoliaVersion = "0.12.2"
 lazy val refinedVersion  = "0.9.12"
 

--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -4,13 +4,10 @@ import java.io.{ File, FileInputStream }
 import java.util.Properties
 
 import zio.system.System
-import zio.system.System.Live.system.lineSeparator
-import zio.{ IO, Task, ZIO }
+import zio.{ system, IO, Tagged, ZEnv, ZIO, ZLayer }
 
-trait Config[A] { self =>
-  def config: Config.Service[A]
-}
 object Config {
+
   trait Service[A] {
     def config: A
   }
@@ -18,63 +15,64 @@ object Config {
   def make[K, V, A](
     source: ConfigSource[K, V],
     configDescriptor: ConfigDescriptor[K, V, A]
-  ): IO[ReadErrors[Vector[K], V], Config[A]] =
-    read(configDescriptor from source)
-      .map(
-        e =>
-          new Config[A] {
-            override def config: Service[A] =
-              new Service[A] {
-                override def config: A = e
-              }
-          }
-      )
+  )(implicit tagged: Tagged[Service[A]]): ZLayer.NoDeps[ReadErrors[Vector[K], V], Config[A]] =
+    ZLayer.fromEffect(makeM(source, configDescriptor))
+
+  def makeM[K, V, A](
+    source: ConfigSource[K, V],
+    configDescriptor: ConfigDescriptor[K, V, A]
+  ): IO[ReadErrors[Vector[K], V], Service[A]] =
+    read(configDescriptor from source).map { e =>
+      new Service[A] {
+        override def config: A = e
+      }
+    }
 
   def fromEnv[K, V, A](
     configDescriptor: ConfigDescriptor[String, String, A],
     valueDelimiter: Option[String] = None
-  ): IO[ReadErrors[Vector[String], String], Config[A]] =
+  )(implicit tagged: Tagged[Service[A]]): ZLayer.NoDeps[ReadErrors[Vector[String], String], Config[A]] =
     make(ConfigSource.fromEnv(valueDelimiter), configDescriptor)
 
   def fromMap[A](
     map: Map[String, String],
     configDescriptor: ConfigDescriptor[String, String, A],
     pathDelimiter: String = "."
-  ): IO[ReadErrors[Vector[String], String], Config[A]] =
+  )(implicit tagged: Tagged[Service[A]]): ZLayer.NoDeps[ReadErrors[Vector[String], String], Config[A]] =
     make[String, String, A](ConfigSource.fromMap(map, pathDelimiter), configDescriptor)
 
   def fromMultiMap[A](
     map: Map[String, ::[String]],
     configDescriptor: ConfigDescriptor[String, String, A],
     pathDelimiter: String = "."
-  ): IO[ReadErrors[Vector[String], String], Config[A]] =
+  )(implicit tagged: Tagged[Service[A]]): ZLayer.NoDeps[ReadErrors[Vector[String], String], Config[A]] =
     make[String, String, A](ConfigSource.fromMultiMap(map, pathDelimiter), configDescriptor)
 
   // If reading a file, this can have read errors as well as throwable when trying to read the file
   def fromPropertyFile[A](
     filePath: String,
     configDescriptor: ConfigDescriptor[String, String, A]
-  ): Task[Config[A]] =
-    ZIO
-      .bracket(ZIO.effect(new FileInputStream(new File(filePath))))(r => ZIO.effectTotal(r.close()))(inputStream => {
-        ZIO.effect {
-          val properties = new Properties()
-          properties.load(inputStream)
-          properties
-        }
-      })
-      .flatMap(
-        properties =>
-          lineSeparator.flatMap(
-            ln =>
-              make(ConfigSource.fromJavaProperties(properties), configDescriptor)
-                .mapError(r => new RuntimeException(s"${ln}${r.mkString(ln)}"))
-          )
-      )
+  )(implicit tagged: Tagged[Service[A]]): ZLayer.NoDeps[Throwable, Config[A]] =
+    ZLayer.fromEffect(
+      for {
+        properties <- ZIO.bracket(ZIO.effect(new FileInputStream(new File(filePath))))(r => ZIO.effectTotal(r.close()))(
+                       inputStream => {
+                         ZIO.effect {
+                           val properties = new Properties()
+                           properties.load(inputStream)
+                           properties
+                         }
+                       }
+                     )
+        ln <- system.lineSeparator.provideLayer(ZEnv.live)
+        config <- makeM(ConfigSource.fromJavaProperties(properties), configDescriptor)
+                   .mapError(r => new RuntimeException(s"${ln}${r.mkString(ln)}"))
+      } yield config
+    )
 
   def fromPropertyFile[K, V, A](
     configDescriptor: ConfigDescriptor[String, String, A],
     valueDelimiter: Option[String] = None
-  ): ZIO[System, ReadErrors[Vector[String], String], Config[A]] =
+  )(implicit tagged: Tagged[Service[A]]): ZLayer[System, ReadErrors[Vector[String], String], Config[A]] =
     make(ConfigSource.fromProperty(valueDelimiter), configDescriptor)
 }

--- a/core/src/main/scala/zio/config/ConfigDescriptor.scala
+++ b/core/src/main/scala/zio/config/ConfigDescriptor.scala
@@ -6,47 +6,6 @@ import java.net.URI
 import zio.config.ConfigDescriptor._
 
 sealed trait ConfigDescriptor[K, V, A] { self =>
-  final def zip[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, (A, B)] =
-    ConfigDescriptor.Zip(self, that)
-
-  final def <*>[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, (A, B)] =
-    self zip that
-
-  final def xmapEither[B](
-    f: A => Either[String, B]
-  )(g: B => Either[String, A]): ConfigDescriptor[K, V, B] =
-    ConfigDescriptor.XmapEither(self, f, g)
-
-  def xmapEither2[B, C](
-    that: ConfigDescriptor[K, V, B]
-  )(f: (A, B) => Either[String, C])(g: C => Either[String, (A, B)]): ConfigDescriptor[K, V, C] =
-    (self |@| that).apply[(A, B)](Tuple2.apply, Tuple2.unapply).xmapEither({ case (a, b) => f(a, b) })(g)
-
-  final def xmap[B](to: A => B)(from: B => A): ConfigDescriptor[K, V, B] =
-    self.xmapEither(a => Right(to(a)))(b => Right(from(b)))
-
-  final def orElseEither[B](
-    that: => ConfigDescriptor[K, V, B]
-  ): ConfigDescriptor[K, V, Either[A, B]] =
-    ConfigDescriptor.OrElseEither(self, that)
-
-  final def <+>[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, Either[A, B]] =
-    self orElseEither that
-
-  final def orElse(that: => ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
-    ConfigDescriptor.OrElse(self, that)
-
-  final def <>(that: => ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
-    self orElse that
-
-  final def optional: ConfigDescriptor[K, V, Option[A]] =
-    ConfigDescriptor.Optional(self) ?? "optional value"
-
-  final def default(value: A): ConfigDescriptor[K, V, A] =
-    ConfigDescriptor.Default(self, value) ?? s"default value: $value ("
-
-  final def describe(description: String): ConfigDescriptor[K, V, A] =
-    ConfigDescriptor.Describe(self, description)
 
   final def ??(description: String): ConfigDescriptor[K, V, A] =
     describe(description)
@@ -57,8 +16,34 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
       override val b: ConfigDescriptor[K, V, B] = f
     }
 
+  final def <>(that: => ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
+    self orElse that
+
+  final def <*>[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, (A, B)] =
+    self zip that
+
+  final def <+>[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, Either[A, B]] =
+    self orElseEither that
+
+  final def default(value: A): ConfigDescriptor[K, V, A] =
+    ConfigDescriptor.Default(self, value) ?? s"default value: $value ("
+
+  final def describe(description: String): ConfigDescriptor[K, V, A] =
+    ConfigDescriptor.Describe(self, description)
+
   final def from(that: ConfigSource[K, V]): ConfigDescriptor[K, V, A] =
     self.updateSource(_.orElse(that))
+
+  final def optional: ConfigDescriptor[K, V, Option[A]] =
+    ConfigDescriptor.Optional(self) ?? "optional value"
+
+  final def orElse(that: => ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
+    ConfigDescriptor.OrElse(self, that)
+
+  final def orElseEither[B](
+    that: => ConfigDescriptor[K, V, B]
+  ): ConfigDescriptor[K, V, Either[A, B]] =
+    ConfigDescriptor.OrElseEither(self, that)
 
   final def unsourced: ConfigDescriptor[K, V, A] =
     self.updateSource(_ => ConfigSource.empty)
@@ -78,22 +63,48 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
     }
     loop(self)
   }
+
+  final def zip[B](that: => ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, (A, B)] =
+    ConfigDescriptor.Zip(self, that)
+
+  final def xmapEither[B](
+    f: A => Either[String, B]
+  )(g: B => Either[String, A]): ConfigDescriptor[K, V, B] =
+    ConfigDescriptor.XmapEither(self, f, g)
+
+  def xmapEither2[B, C](
+    that: ConfigDescriptor[K, V, B]
+  )(f: (A, B) => Either[String, C])(g: C => Either[String, (A, B)]): ConfigDescriptor[K, V, C] =
+    (self |@| that).apply[(A, B)](Tuple2.apply, Tuple2.unapply).xmapEither({ case (a, b) => f(a, b) })(g)
+
+  final def xmap[B](to: A => B)(from: B => A): ConfigDescriptor[K, V, B] =
+    self.xmapEither(a => Right(to(a)))(b => Right(from(b)))
 }
 
 object ConfigDescriptor {
-  final case class Source[K, V, A](path: K, source: ConfigSource[K, V], propertyType: PropertyType[V, A])
-      extends ConfigDescriptor[K, V, A]
 
-  final case class Sequence[K, V, A](config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, List[A]]
-
-  final case class Nested[K, V, A](path: K, config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, A]
+  final case class Default[K, V, A](config: ConfigDescriptor[K, V, A], value: A) extends ConfigDescriptor[K, V, A]
 
   final case class Describe[K, V, A](config: ConfigDescriptor[K, V, A], message: String)
       extends ConfigDescriptor[K, V, A]
 
-  final case class Default[K, V, A](config: ConfigDescriptor[K, V, A], value: A) extends ConfigDescriptor[K, V, A]
+  final case class Nested[K, V, A](path: K, config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, A]
 
   final case class Optional[K, V, A](config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, Option[A]]
+
+  final case class OrElse[K, V, A](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, A])
+      extends ConfigDescriptor[K, V, A]
+
+  final case class OrElseEither[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
+      extends ConfigDescriptor[K, V, Either[A, B]]
+
+  final case class Sequence[K, V, A](config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, List[A]]
+
+  final case class Source[K, V, A](path: K, source: ConfigSource[K, V], propertyType: PropertyType[V, A])
+      extends ConfigDescriptor[K, V, A]
+
+  final case class Zip[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
+      extends ConfigDescriptor[K, V, (A, B)]
 
   final case class XmapEither[K, V, A, B](
     config: ConfigDescriptor[K, V, A],
@@ -101,14 +112,41 @@ object ConfigDescriptor {
     g: B => Either[String, A]
   ) extends ConfigDescriptor[K, V, B]
 
-  final case class Zip[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
-      extends ConfigDescriptor[K, V, (A, B)]
+  def bigDecimal(path: String): ConfigDescriptor[String, String, BigDecimal] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigDecimalType) ?? "value of type bigdecimal"
 
-  final case class OrElseEither[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
-      extends ConfigDescriptor[K, V, Either[A, B]]
+  def bigInt(path: String): ConfigDescriptor[String, String, BigInt] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigIntType) ?? "value of type bigint"
 
-  final case class OrElse[K, V, A](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, A])
-      extends ConfigDescriptor[K, V, A]
+  def boolean(path: String): ConfigDescriptor[String, String, Boolean] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BooleanType) ?? "value of type boolean"
+
+  def byte(path: String): ConfigDescriptor[String, String, Byte] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ByteType) ?? "value of type byte"
+
+  def collectAll[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] =
+    sequence(configList)
+
+  def double(path: String): ConfigDescriptor[String, String, Double] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DoubleType) ?? "value of type double"
+
+  def duration(path: String): ConfigDescriptor[String, String, Duration] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DurationType) ?? "value of type duration"
+
+  def float(path: String): ConfigDescriptor[String, String, Float] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.FloatType) ?? "value of type float"
+
+  def int(path: String): ConfigDescriptor[String, String, Int] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.IntType) ?? "value of type int"
+
+  def list[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
+    ConfigDescriptor.Sequence(desc)
+
+  def long(path: String): ConfigDescriptor[String, String, Long] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.LongType) ?? "value of type long"
+
+  def nested[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
+    ConfigDescriptor.Nested(path, desc)
 
   def sequence[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] = {
     val reversed = configList.reverse
@@ -124,37 +162,12 @@ object ConfigDescriptor {
     )
   }
 
-  def collectAll[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] =
-    sequence(configList)
-
-  def list[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
-    ConfigDescriptor.Sequence(desc)
-
-  def nested[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
-    ConfigDescriptor.Nested(path, desc)
+  def short(path: String): ConfigDescriptor[String, String, Short] =
+    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ShortType) ?? "value of type short"
 
   def string(path: String): ConfigDescriptor[String, String, String] =
     ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.StringType) ?? "value of type string"
-  def boolean(path: String): ConfigDescriptor[String, String, Boolean] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BooleanType) ?? "value of type boolean"
-  def byte(path: String): ConfigDescriptor[String, String, Byte] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ByteType) ?? "value of type byte"
-  def short(path: String): ConfigDescriptor[String, String, Short] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ShortType) ?? "value of type short"
-  def int(path: String): ConfigDescriptor[String, String, Int] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.IntType) ?? "value of type int"
-  def long(path: String): ConfigDescriptor[String, String, Long] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.LongType) ?? "value of type long"
-  def bigInt(path: String): ConfigDescriptor[String, String, BigInt] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigIntType) ?? "value of type bigint"
-  def float(path: String): ConfigDescriptor[String, String, Float] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.FloatType) ?? "value of type float"
-  def double(path: String): ConfigDescriptor[String, String, Double] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DoubleType) ?? "value of type double"
-  def bigDecimal(path: String): ConfigDescriptor[String, String, BigDecimal] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigDecimalType) ?? "value of type bigdecimal"
+
   def uri(path: String): ConfigDescriptor[String, String, URI] =
     ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.UriType) ?? "value of type uri"
-  def duration(path: String): ConfigDescriptor[String, String, Duration] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DurationType) ?? "value of type duration"
 }

--- a/core/src/main/scala/zio/config/ConfigSource.scala
+++ b/core/src/main/scala/zio/config/ConfigSource.scala
@@ -1,7 +1,6 @@
 package zio.config
 
-import zio.{ IO, ZIO }
-import zio.system.System.Live.system
+import zio.{ system, IO, ZEnv, ZIO }
 import java.{ util => ju }
 
 final case class ConfigValue[A](value: ::[A])
@@ -55,7 +54,7 @@ object ConfigSource {
           )
           .flatMap(IO.fromOption(_))
           .mapError(_ => singleton(ReadError.MissingValue(path)))
-
+          .provideLayer(ZEnv.live)
       },
       SystemEnvironment :: Nil
     )
@@ -85,6 +84,7 @@ object ConfigSource {
           )
           .flatMap(IO.fromOption(_))
           .mapError(_ => singleton(ReadError.MissingValue(path)))
+          .provideLayer(ZEnv.live)
 
       },
       SystemProperties :: Nil

--- a/core/src/main/scala/zio/config/ConfigSource.scala
+++ b/core/src/main/scala/zio/config/ConfigSource.scala
@@ -1,6 +1,7 @@
 package zio.config
 
-import zio.{ system, IO, ZEnv, ZIO }
+import zio.{ system, IO, ZIO }
+import zio.system.System
 import java.{ util => ju }
 
 final case class ConfigValue[A](value: ::[A])
@@ -53,8 +54,8 @@ object ConfigSource {
               })
           )
           .flatMap(IO.fromOption(_))
-          .mapError(_ => singleton(ReadError.MissingValue(path)))
-          .provideLayer(ZEnv.live)
+          .mapError[ReadErrorsVector[String, String]](_ => singleton(ReadError.MissingValue(path)))
+          .provideLayer(System.live)
       },
       SystemEnvironment :: Nil
     )
@@ -83,9 +84,8 @@ object ConfigSource {
               })
           )
           .flatMap(IO.fromOption(_))
-          .mapError(_ => singleton(ReadError.MissingValue(path)))
-          .provideLayer(ZEnv.live)
-
+          .mapError[ReadErrorsVector[String, String]](_ => singleton(ReadError.MissingValue(path)))
+          .provideLayer(System.live)
       },
       SystemProperties :: Nil
     )
@@ -137,7 +137,6 @@ object ConfigSource {
           )
           .flatMap(IO.fromOption(_))
           .mapError(_ => singleton(ReadError.MissingValue(path)))
-
       },
       JavaProperties :: Nil
     )

--- a/core/src/main/scala/zio/config/ReadFunctions.scala
+++ b/core/src/main/scala/zio/config/ReadFunctions.scala
@@ -4,10 +4,12 @@ import zio.{ IO, ZIO }
 import zio.config.ConfigDescriptor.Sequence
 
 private[config] trait ReadFunctions {
+
   // Read
   final def read[K, V, A](
     configuration: ConfigDescriptor[K, V, A]
   ): IO[ReadErrorsVector[K, V], A] = {
+
     def loop[V1, B](
       configuration: ConfigDescriptor[K, V1, B],
       paths: Vector[K]

--- a/core/src/main/scala/zio/config/WriteFunctions.scala
+++ b/core/src/main/scala/zio/config/WriteFunctions.scala
@@ -1,6 +1,7 @@
 package zio.config
 
 private[config] trait WriteFunctions {
+
   final def write[K, V, A](config: ConfigDescriptor[K, V, A], a: A): Either[String, PropertyTree[K, V]] = {
     def go[B](config: ConfigDescriptor[K, V, B], b: B): Either[String, PropertyTree[K, V]] =
       config match {

--- a/core/src/main/scala/zio/config/package.scala
+++ b/core/src/main/scala/zio/config/package.scala
@@ -1,11 +1,14 @@
 package zio
 
 package object config extends ReadFunctions with WriteFunctions with ConfigDocsFunctions {
+
+  type Config[A] = Has[Config.Service[A]]
+
   final type ReadErrors[K, V]       = ::[ReadError[K, V]]
   final type ReadErrorsVector[K, V] = ReadErrors[Vector[K], V]
 
-  final def config[A]: ZIO[Config[A], Nothing, A] =
-    ZIO.access(_.config.config)
+  final def config[A](implicit tagged: Tagged[Config.Service[A]]): ZIO[Config[A], Nothing, A] =
+    ZIO.access(_.get.config)
 
   private[config] def concat[A](l: ::[A], r: ::[A]): ::[A] =
     ::(l.head, l.tail ++ r)

--- a/core/src/test/scala/zio/config/BaseSpec.scala
+++ b/core/src/test/scala/zio/config/BaseSpec.scala
@@ -4,5 +4,6 @@ import zio.duration._
 import zio.test.{ DefaultRunnableSpec, TestAspect, ZSpec }
 import zio.test.environment.TestEnvironment
 
-abstract class BaseSpec(spec: => ZSpec[TestEnvironment, Any, String, Any])
-    extends DefaultRunnableSpec(spec, List(TestAspect.timeout(1.minute)))
+abstract class BaseSpec(override val spec: ZSpec[TestEnvironment, Any]) extends DefaultRunnableSpec {
+  override def aspects = List(TestAspect.timeout(60.seconds))
+}

--- a/core/src/test/scala/zio/config/PropertyTypeTest.scala
+++ b/core/src/test/scala/zio/config/PropertyTypeTest.scala
@@ -91,12 +91,13 @@ object PropertyTypeTest
     )
 
 object PropertyTypeTestUtils {
+
   def propertyTypeRoundtripSuite[A](
     typeInfo: String,
     propType: PropertyType[String, A],
     genValid: Gen[Random with Sized, String],
     parse: String => A
-  ): Spec[TestEnvironment, TestFailure[Nothing], String, TestSuccess[Unit]] =
+  ): Spec[TestEnvironment, TestFailure[Nothing], TestSuccess] =
     suite(s"${typeInfo}Type")(
       testM(s"valid ${typeInfo} string roundtrip") {
         check(genValid.map(_.toString))(assertValidRoundtrip(propType, parse))

--- a/docs/configdescriptor/index.md
+++ b/docs/configdescriptor/index.md
@@ -8,7 +8,7 @@ or rely on zio-config-magnolia that can automatically generate the description f
 that represents your config.
 
 ```scala mdoc:silent
-import zio.IO
+import zio.{ IO, ZLayer }
 import zio.config._, ConfigDescriptor._
 ```
 
@@ -31,7 +31,7 @@ val myConfig =
 
 ```
 
-Type of `myConfig` is `ConfigDescriptor[String, String, MyConfig]`. 
+Type of `myConfig` is `ConfigDescriptor[String, String, MyConfig]`.
 
 ## Fully Automated Config Description: zio-config-magnolia
 
@@ -46,10 +46,10 @@ val myConfigAutomatic = description[MyConfig]
 
 ```
 
-`myConfig` and `myConfigAutomatic` are same description, and is of the same type. 
+`myConfig` and `myConfigAutomatic` are same description, and is of the same type.
 
 If you need more control over the description,
-probably you may choose to write it manually (such as, for adding extra documentations). 
+probably you may choose to write it manually (such as, for adding extra documentations).
 More examples on automatic derivation is in examples module of [zio-config](https://github.com/zio/zio-config)
 
 ## Running the description to ZIO
@@ -58,7 +58,7 @@ To read a config, means it has to perform some effects, and for that reason, it 
 To be specific it returns an `IO` where `type IO[E, A] = ZIO[Any, E, A]`
 
 ```scala mdoc:silent
-val result: IO[ReadErrorsVector[String, String], zio.config.Config[MyConfig]] = 
+val result: ZLayer.NoDeps[ReadErrors[Vector[String], String], zio.config.Config[MyConfig]] =
   Config.fromEnv(myConfig) // That's system environment
 ```
 

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -67,11 +67,11 @@ Let's define a simple one.
 val myConfig =
   (string("LDAP") |@| int("PORT")|@| string("DB_URL"))(MyConfig.apply, MyConfig.unapply)
 
- // ConfigDescriptor[String, String, MyConfig] 
+ // ConfigDescriptor[String, String, MyConfig]
 
 ```
 
-Type of `myConfig` is `ConfigDescriptor[String, String, MyConfig]`. 
+Type of `myConfig` is `ConfigDescriptor[String, String, MyConfig]`.
 
 ## Fully automated Config Description
 
@@ -98,21 +98,21 @@ There are more information on various sources in [here](../sources/index.md).
 Below given is a simple example.
 
 ```scala mdoc:silent
-val map = 
+val map =
   Map(
     "LDAP" -> "xyz",
     "PORT" -> "8888",
     "DB_URL" -> "postgres"
   )
 
-  val result = 
+  val result =
     Config.fromMap(map, myConfig)
 
-  // IO[ReadErrorsVector[String, String], zio.config.Config[MyConfig]]   
+  // IO[ReadErrorsVector[String, String], zio.config.Config[MyConfig]]
 
 ```
 
-You can run this to [completion](https://zio.dev/docs/getting_started.html#main) as in any zio application. 
+You can run this to [completion](https://zio.dev/docs/getting_started.html#main) as in any zio application.
 
 ## How to use config descriptor
 
@@ -123,7 +123,7 @@ As mentioned before, you can use config descriptor to read from various sources.
 ```scala mdoc:silent
 val source = ConfigSource.fromMap(map)
 
-val anotherResult = 
+val anotherResult =
   read(myConfig from source)
 // IO[ReadErrorsVector[String, String], MyConfig]
 ```
@@ -139,8 +139,8 @@ generateDocs(myConfig)
 //Creates documentation (automatic)
 
 
-val betterConfig = 
-  (string("LDAP") ?? "Related to auth" |@|  int("PORT") ?? "Database port" |@| 
+val betterConfig =
+  (string("LDAP") ?? "Related to auth" |@|  int("PORT") ?? "Database port" |@|
     string("DB_URL") ?? "url of database"
    )(MyConfig.apply, MyConfig.unapply)
 
@@ -181,26 +181,24 @@ This will tell you how to consider configuration as just a part of `Environment`
 
 ```scala mdoc:silent
 
-import zio.ZIO
-import zio.console.Console.Live.console._
+import zio.{ ZIO, ZLayer }
+import zio.console._
 
 case class ApplicationConfig(bridgeIp: String, userName: String)
 
 val configuration =
   (string("bridgeIp") |@| string("username"))(ApplicationConfig.apply, ApplicationConfig.unapply)
 
-val finalExecution: ZIO[Config[ApplicationConfig], Nothing, Unit] =
+val finalExecution: ZIO[Config[ApplicationConfig] with Console, Nothing, Unit] =
   for {
     appConfig <- config[ApplicationConfig]
     _         <- putStrLn(appConfig.bridgeIp)
     _         <- putStrLn(appConfig.userName)
   } yield ()
 
-// Main App  
-val pgm = 
-  for {
-    config <- Config.fromPropertyFile("file-location", configuration)
-    _      <- finalExecution.provide(config)
-  } yield ()  
+val configLayer = Config.fromPropertyFile("file-location", configuration)
+
+// Main App
+val pgm = finalExecution.provideLayer(configLayer ++ Console.live)
 
 ```

--- a/docs/usingconfigdescriptor/index.md
+++ b/docs/usingconfigdescriptor/index.md
@@ -40,7 +40,7 @@ Let's define a simple one.
 val myConfig =
   (string("LDAP") |@| int("PORT")|@| string("DB_URL"))(MyConfig.apply, MyConfig.unapply)
 
-read(myConfig from ConfigSource.fromMap(Map()))  
+read(myConfig from ConfigSource.fromMap(Map()))
 
 ```
 
@@ -50,13 +50,15 @@ read(myConfig from ConfigSource.fromMap(Map()))
 To write a configured value back:
 
 ```scala mdoc:silent
+import zio.Runtime
+
   case class Database(url: String, port: Int)
   case class AwsConfig(c1: Database, c2: Database, c3: String)
 
   val database =
     (string("connection") |@| int("port"))(Database.apply, Database.unapply)
 
-  val map = 
+  val map =
     Map(
       "south.connection" -> "abc.com",
       "south.port" -> "8111",
@@ -68,20 +70,18 @@ To write a configured value back:
   val appConfig =
     (((nested("south") { database } ?? "South details" |@|
       nested("east") { database } ?? "East details" |@|
-      string("appName"))(AwsConfig, AwsConfig.unapply)) ?? "asdf"  
+      string("appName"))(AwsConfig, AwsConfig.unapply)) ?? "asdf"
     ) from ConfigSource.fromMap(map)
- 
-  val awsConfig = 
+
+  val awsConfig =
     read(appConfig)
 
-  val runtime = new zio.DefaultRuntime{}
-
-  val awsConfigReuslt: AwsConfig = runtime.unsafeRun(awsConfig)
+  val awsConfigReuslt: AwsConfig = Runtime.default.unsafeRun(awsConfig)
    // yields AwsConfig(Database(abc.com, 8111), Database(xyz.com, 8888), myApp)
-     
+
 write(appConfig, awsConfigReuslt)
 
-// yields 
+// yields
 
  Right(
     Record(

--- a/examples/src/main/scala/zio/config/examples/SimpleExampleUsingJavaProperties.scala
+++ b/examples/src/main/scala/zio/config/examples/SimpleExampleUsingJavaProperties.scala
@@ -1,10 +1,10 @@
 package zio.config.examples
 
 import zio.App
-import zio.config._
-import ConfigDescriptor._
-import zio.ZIO
-import zio.console.Console.Live.console._
+import zio.{ config, console, ZEnv, ZIO, ZLayer }
+import zio.config.Config
+import zio.config.ConfigDescriptor._
+import zio.console.Console
 
 /**
  * An example of an entire application that uses java properties
@@ -18,35 +18,37 @@ object ApplicationConfig {
 
 // The main App
 object SimpleExampleMain extends App {
-  override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] = {
+
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
     val pgm =
       for {
         fileLocation <- ZIO.effect(System.getProperty("user.home") + "/somefile.properties")
         // there are many ways of doing this: example: {{{ read(configuration from ConfigSource.fromJavaProperties(propertyFile))) }}}, you may try that as well.
-        config <- Config.fromPropertyFile(fileLocation, ApplicationConfig.configuration)
-        _      <- SimpleExample.finalExecution.provide(config)
+        configLayer = Config.fromPropertyFile(fileLocation, ApplicationConfig.configuration)
+        _           <- SimpleExample.finalExecution.provideLayer(configLayer ++ ZLayer.requires[Console])
       } yield ()
 
     pgm.foldM(
-      throwable => putStr(throwable.getMessage()) *> ZIO.succeed(1),
-      _ => putStrLn("hurray !! Application ran successfully..") *> ZIO.succeed(0)
+      throwable => console.putStr(throwable.getMessage()) *> ZIO.succeed(1),
+      _ => console.putStrLn("hurray !! Application ran successfully..") *> ZIO.succeed(0)
     )
   }
 }
 
 // The core application functions
 object SimpleExample {
-  val printConfigs: ZIO[Config[ApplicationConfig], Nothing, Unit] =
+
+  val printConfigs: ZIO[Console with Config[ApplicationConfig], Nothing, Unit] =
     for {
-      appConfig <- config[ApplicationConfig]
-      _         <- putStrLn(appConfig.bridgeIp)
-      _         <- putStrLn(appConfig.userName)
+      appConfig <- config.config[ApplicationConfig]
+      _         <- console.putStrLn(appConfig.bridgeIp)
+      _         <- console.putStrLn(appConfig.userName)
     } yield ()
 
-  val finalExecution: ZIO[Config[ApplicationConfig], Nothing, Unit] =
+  val finalExecution: ZIO[Console with Config[ApplicationConfig], Nothing, Unit] =
     for {
       _ <- printConfigs
-      _ <- putStrLn(s"processing data......")
+      _ <- console.putStrLn(s"processing data......")
     } yield ()
 }
 // A note that, with magnolia module (which is still experimental), you can skip writing the {{ configuration }} in ApplicationConfig object

--- a/examples/src/main/scala/zio/config/examples/magnolia/AutomaticConfigDescExample.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/AutomaticConfigDescExample.scala
@@ -1,11 +1,10 @@
 package zio.config.examples.magnolia
 
-import zio.ZIO
+import zio.{ console, App, ZEnv, ZIO }
 import zio.config.ConfigSource
 import zio.config.magnolia.describe
 import zio.config.examples.magnolia.MyConfig._
 import zio.config.magnolia.ConfigDescriptorProvider._
-import zio.console.Console.Live.console._
 
 final case class MyConfig(
   aws: Aws,
@@ -33,7 +32,7 @@ object MyConfig {
   final case class DbUrl(value: String) extends AnyVal
 }
 
-object AutomaticConfigDescriptor extends zio.App {
+object AutomaticConfigDescriptor extends App {
   // Typeclass derivation through Magnolia
   private val automaticConfig = description[MyConfig]
 
@@ -57,13 +56,13 @@ object AutomaticConfigDescriptor extends zio.App {
 
   import zio.config._
 
-  override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
     read(config).foldM(
-      r => putStrLn(r.mkString(",")) *> ZIO.succeed(1),
+      r => console.putStrLn(r.mkString(",")) *> ZIO.succeed(1),
       result =>
-        putStrLn(result.toString()) *> putStrLn(write(config, result).toString()) *> putStrLn(
-          generateDocs(config).toString()
-        ) *>
+        console.putStrLn(result.toString()) *>
+          console.putStrLn(write(config, result).toString()) *>
+          console.putStrLn(generateDocs(config).toString()) *>
           ZIO.succeed(0)
     )
   //

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -33,7 +33,7 @@ object RefinedReadConfig extends App {
     ZIO.access[RefinedProd](_.longs)
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
-    ZIO.accessM { env =>
+    ZIO.accessM { _ =>
       val configMultiMap =
         Map(
           "LDAP"     -> ::("ldap", Nil),

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -32,25 +32,24 @@ object RefinedReadConfig extends App {
   val myAppLogic: ZIO[RefinedProd, Nothing, Refined[List[Long], Size[Greater[W.`2`.T]]]] =
     ZIO.access[RefinedProd](_.longs)
 
-  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
-    ZIO.accessM { _ =>
-      val configMultiMap =
-        Map(
-          "LDAP"     -> ::("ldap", Nil),
-          "PORT"     -> ::("1999", Nil),
-          "DB_URL"   -> ::("ddd", Nil),
-          "LONGVALS" -> ::("1234", List("2345", "3456"))
-        )
-
-      val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =
-        for {
-          config <- read(prodConfig.from(ConfigSource.fromMultiMap(configMultiMap)))
-          r      <- myAppLogic.provide(config)
-        } yield r
-
-      outcome.foldM(
-        failure => console.putStrLn(failure.toString) *> ZIO.succeed(1),
-        r => console.putStrLn(s"👍 $r") *> ZIO.succeed(0)
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
+    val configMultiMap =
+      Map(
+        "LDAP"     -> ::("ldap", Nil),
+        "PORT"     -> ::("1999", Nil),
+        "DB_URL"   -> ::("ddd", Nil),
+        "LONGVALS" -> ::("1234", List("2345", "3456"))
       )
-    }
+
+    val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =
+      for {
+        config <- read(prodConfig.from(ConfigSource.fromMultiMap(configMultiMap)))
+        r      <- myAppLogic.provide(config)
+      } yield r
+
+    outcome.foldM(
+      failure => console.putStrLn(failure.toString) *> ZIO.succeed(1),
+      r => console.putStrLn(s"👍 $r") *> ZIO.succeed(0)
+    )
+  }
 }

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -7,9 +7,10 @@ import eu.timepit.refined.numeric.{ Greater, GreaterEqual }
 import zio.config.ConfigDescriptor.{ int, list, long, string }
 import zio.config.refined.{ greaterEqual, nonEmpty, size }
 import zio.config.{ read, ConfigDescriptor, ConfigSource, ReadErrors }
-import zio.{ App, ZEnv, ZIO }
+import zio.{ console, App, ZEnv, ZIO }
 
 object RefinedReadConfig extends App {
+
   case class RefinedProd(
     ldap: Refined[String, NonEmpty],
     port: Refined[Int, GreaterEqual[W.`1024`.T]],
@@ -40,6 +41,7 @@ object RefinedReadConfig extends App {
           "DB_URL"   -> ::("ddd", Nil),
           "LONGVALS" -> ::("1234", List("2345", "3456"))
         )
+
       val outcome: ZIO[Any, ReadErrors[Vector[String], String], Refined[List[Long], Size[Greater[W.`2`.T]]]] =
         for {
           config <- read(prodConfig.from(ConfigSource.fromMultiMap(configMultiMap)))
@@ -47,8 +49,8 @@ object RefinedReadConfig extends App {
         } yield r
 
       outcome.foldM(
-        failure => env.console.putStrLn(failure.toString) *> ZIO.succeed(1),
-        r => env.console.putStrLn(s"👍 $r") *> ZIO.succeed(0)
+        failure => console.putStrLn(failure.toString) *> ZIO.succeed(1),
+        r => console.putStrLn(s"👍 $r") *> ZIO.succeed(0)
       )
     }
 }

--- a/magnolia/src/main/scala/zio/config/magnolia/ConfigDescriptorProvider.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/ConfigDescriptorProvider.scala
@@ -1,8 +1,7 @@
 package zio.config.magnolia
 
 import java.net.URI
-import zio.config.{ ConfigDescriptor }
-import ConfigDescriptor._
+import zio.config.ConfigDescriptor, ConfigDescriptor._
 import magnolia._
 import scala.util.Success
 import scala.util.Failure
@@ -13,6 +12,7 @@ trait ConfigDescriptorProvider[T] {
 }
 
 object ConfigDescriptorProvider {
+
   def apply[T](implicit ev: ConfigDescriptorProvider[T]): ConfigDescriptorProvider[T] = ev
 
   def instance[T](f: String => ConfigDescriptor[String, String, T]): ConfigDescriptorProvider[T] =

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -6,8 +6,9 @@ import sbtbuildinfo._
 import BuildInfoKeys._
 
 object BuildHelper {
-  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.3" % "test")
-  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.2"  % "provided")
+
+  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.3" % Test)
+  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.4"  % Provided cross CrossVersion.full)
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -75,12 +76,12 @@ object BuildHelper {
   def stdSettings(prjName: String) = Seq(
     name := s"$prjName",
     scalacOptions := stdOptions,
-    crossScalaVersions := Seq("2.13.0", "2.12.10"),
+    crossScalaVersions := Seq("2.13.1", "2.12.10"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value),
     libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(
       compilerPlugin("org.typelevel"   %% "kind-projector"  % "0.10.3"),
-      compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2")
+      compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.4" cross CrossVersion.full)
     ),
     parallelExecution in Test := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),

--- a/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
@@ -4,33 +4,37 @@ import zio.config._, Config._
 import java.io.File
 import zio.ZIO
 import com.typesafe.config.ConfigFactory
-import zio.system.System.Live.system.lineSeparator
-import zio.Task
+import zio.{ system, Tagged, ZEnv, ZLayer }
 
 object TypesafeConfig {
 
-  def fromDefaultLoader[A](configDescriptor: ConfigDescriptor[String, String, A]): Task[Config[A]] =
+  def fromDefaultLoader[A](
+    configDescriptor: ConfigDescriptor[String, String, A]
+  )(implicit tagged: Tagged[Config.Service[A]]): ZLayer.NoDeps[Throwable, Config[A]] =
     fromHocon(ConfigFactory.load.resolve, configDescriptor)
 
-  def fromHoconFile[A](configDescriptor: ConfigDescriptor[String, String, A], file: File): Task[Config[A]] =
+  def fromHoconFile[A](
+    configDescriptor: ConfigDescriptor[String, String, A],
+    file: File
+  )(implicit tagged: Tagged[Config.Service[A]]): ZLayer.NoDeps[Throwable, Config[A]] =
     fromHocon(ConfigFactory.parseFile(file).resolve, configDescriptor)
 
-  def fromHoconString[A](str: String, configDescriptor: ConfigDescriptor[String, String, A]): Task[Config[A]] =
+  def fromHoconString[A](
+    str: String,
+    configDescriptor: ConfigDescriptor[String, String, A]
+  )(implicit tagged: Tagged[Config.Service[A]]): ZLayer.NoDeps[Throwable, Config[A]] =
     fromHocon(ConfigFactory.parseString(str).resolve, configDescriptor)
 
   def fromHocon[A](
     f: => com.typesafe.config.Config,
     configDescriptor: ConfigDescriptor[String, String, A]
-  ): Task[Config[A]] =
-    ZIO
-      .effect(f)
-      .flatMap(
-        conf =>
-          lineSeparator.flatMap(
-            ln =>
-              make(TypeSafeConfigSource.hocon(Left(conf)), configDescriptor)
-                .mapError(r => new RuntimeException(s"${ln}${r.mkString(ln)}"))
-          )
-      )
-
+  )(implicit tagged: Tagged[Config.Service[A]]): ZLayer.NoDeps[Throwable, Config[A]] =
+    ZLayer.fromEffect(
+      for {
+        conf <- ZIO.effect(f)
+        ln   <- system.lineSeparator.provideLayer(ZEnv.live)
+        config <- makeM(TypeSafeConfigSource.hocon(Left(conf)), configDescriptor)
+                   .mapError(r => new RuntimeException(s"${ln}${r.mkString(ln)}"))
+      } yield config
+    )
 }


### PR DESCRIPTION
Same as with [interop-cats#145](https://github.com/zio/interop-cats/pull/145). Been playing around and needed to update `zio-config` to latest ZIO. Tested only on `2.13.1`.

This PR is meant to hang around open until next ZIO release. I'll try to keep it up to date as ZIO Core evolves.