### PR TITLE
Add succeed constructor to Config.Service

### DIFF
--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -12,6 +12,10 @@ object Config {
     def config: A
   }
 
+  def pure[A](a: A): Service[A] = new Service[A] {
+    def config: A = a
+  }
+
   def make[K, V, A](
     source: ConfigSource[K, V],
     configDescriptor: ConfigDescriptor[K, V, A]
@@ -22,11 +26,7 @@ object Config {
     source: ConfigSource[K, V],
     configDescriptor: ConfigDescriptor[K, V, A]
   ): IO[ReadErrors[Vector[K], V], Service[A]] =
-    read(configDescriptor from source).map { e =>
-      new Service[A] {
-        override def config: A = e
-      }
-    }
+    read(configDescriptor from source).map(pure)
 
   def fromEnv[K, V, A](
     configDescriptor: ConfigDescriptor[String, String, A],

--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -12,7 +12,7 @@ object Config {
     def config: A
   }
 
-  def succeed[A](a: A): Service[A] = new Service[A] {
+  def succeed[A](a: => A): Service[A] = new Service[A] {
     def config: A = a
   }
 

--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -12,7 +12,7 @@ object Config {
     def config: A
   }
 
-  def pure[A](a: A): Service[A] = new Service[A] {
+  def succeed[A](a: A): Service[A] = new Service[A] {
     def config: A = a
   }
 
@@ -26,7 +26,7 @@ object Config {
     source: ConfigSource[K, V],
     configDescriptor: ConfigDescriptor[K, V, A]
   ): IO[ReadErrors[Vector[K], V], Service[A]] =
-    read(configDescriptor from source).map(pure)
+    read(configDescriptor from source).map(succeed)
 
   def fromEnv[K, V, A](
     configDescriptor: ConfigDescriptor[String, String, A],

--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -26,7 +26,7 @@ object Config {
     source: ConfigSource[K, V],
     configDescriptor: ConfigDescriptor[K, V, A]
   ): IO[ReadErrors[Vector[K], V], Service[A]] =
-    read(configDescriptor from source).map(succeed)
+    read(configDescriptor from source).map(succeed(_))
 
   def fromEnv[K, V, A](
     configDescriptor: ConfigDescriptor[String, String, A],


### PR DESCRIPTION
Seems useful by itself, but my particular case is simplifying manipulation of already existing service instances.

A particular example is to zoom into a root config layer to get a sub-config for a particular component. Currently you'd have to write smthing like:

```scala
val configLayer = TypesafeConfig.fromDefaultLoader(appConfigDesc)
val dbConfigLayer = configLayer.map(c => Has(new Config.Service[DbConfig] { def config = c.get.config.db }) )
val apiConfigLayer = configLayer.map(c => Has(new Config.Service[ApiConfig] { def config = c.get.config.api }) 
```

With `pure` it becomes much simpler:

```scala
val configLayer = TypesafeConfig.fromDefaultLoader(appConfigDesc)
val dbConfigLayer = configLayer.map(c => Has(Config.pure(c.get.config.db)))
val apiConfigLayer = configLayer.map(c => Has(Config.pure(c.get.config.api)))
```