### PR TITLE
Fix 258, 257 allow ConfigDescriptor without path

### DIFF
--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -34,9 +34,9 @@ object Config {
    *
    *  val credentials = (string("username") |@| string("password"))(Credentials.apply, Credentials.unapply)
    *
-   *  final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String, users: List[String])
+   *  final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String], users: List[String])
    *
-   *  (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions") |@| list(string("user"))(Config.apply, Config.unapply)
+   *  (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions")) |@| list(string("user")))(Config.apply, Config.unapply)
    *
    *  // res0 Config(Credentials(1, hi), Credentials(3, 10), List(111, 122), List(k1, k2))
    *

--- a/core/src/main/scala/zio/config/ConfigDescriptor.scala
+++ b/core/src/main/scala/zio/config/ConfigDescriptor.scala
@@ -43,16 +43,16 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
 
   def mapKey(f: K => K): ConfigDescriptor[K, V, A] = {
     def loop[B](config: ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, B] = config match {
-      case Source(path, source, propertyType) => Source(f(path), source, propertyType)
-      case Nested(path, conf)                 => Nested(f(path), loop(conf))
-      case Sequence(conf)                     => Sequence(loop(conf))
-      case Describe(config, message)          => Describe(loop(config), message)
-      case Default(value, value2)             => Default(loop(value), value2)
-      case Optional(config)                   => Optional(loop(config))
-      case XmapEither(config, f, g)           => XmapEither(loop(config), f, g)
-      case Zip(conf1, conf2)                  => Zip(loop(conf1), loop(conf2))
-      case OrElseEither(value1, value2)       => OrElseEither(loop(value1), loop(value2))
-      case OrElse(value1, value2)             => OrElse(loop(value1), loop(value2))
+      case Source(source, propertyType) => Source(source, propertyType)
+      case Nested(path, conf)           => Nested(f(path), loop(conf))
+      case Sequence(conf)               => Sequence(loop(conf))
+      case Describe(config, message)    => Describe(loop(config), message)
+      case Default(value, value2)       => Default(loop(value), value2)
+      case Optional(config)             => Optional(loop(config))
+      case XmapEither(config, f, g)     => XmapEither(loop(config), f, g)
+      case Zip(conf1, conf2)            => Zip(loop(conf1), loop(conf2))
+      case OrElseEither(value1, value2) => OrElseEither(loop(value1), loop(value2))
+      case OrElse(value1, value2)       => OrElse(loop(value1), loop(value2))
     }
     loop(self)
   }
@@ -73,16 +73,16 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
 
   final def updateSource(f: ConfigSource[K, V] => ConfigSource[K, V]): ConfigDescriptor[K, V, A] = {
     def loop[B](config: ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, B] = config match {
-      case Source(path, source, propertyType) => Source(path, f(source), propertyType)
-      case Nested(path, conf)                 => Nested(path, loop(conf))
-      case Sequence(conf)                     => Sequence(loop(conf))
-      case Describe(config, message)          => Describe(loop(config), message)
-      case Default(value, value2)             => Default(loop(value), value2)
-      case Optional(config)                   => Optional(loop(config))
-      case XmapEither(config, f, g)           => XmapEither(loop(config), f, g)
-      case Zip(conf1, conf2)                  => Zip(loop(conf1), loop(conf2))
-      case OrElseEither(value1, value2)       => OrElseEither(loop(value1), loop(value2))
-      case OrElse(value1, value2)             => OrElse(loop(value1), loop(value2))
+      case Source(source, propertyType) => Source(f(source), propertyType)
+      case Nested(path, conf)           => Nested(path, loop(conf))
+      case Sequence(conf)               => Sequence(loop(conf))
+      case Describe(config, message)    => Describe(loop(config), message)
+      case Default(value, value2)       => Default(loop(value), value2)
+      case Optional(config)             => Optional(loop(config))
+      case XmapEither(config, f, g)     => XmapEither(loop(config), f, g)
+      case Zip(conf1, conf2)            => Zip(loop(conf1), loop(conf2))
+      case OrElseEither(value1, value2) => OrElseEither(loop(value1), loop(value2))
+      case OrElse(value1, value2)       => OrElse(loop(value1), loop(value2))
     }
     loop(self)
   }
@@ -122,7 +122,7 @@ object ConfigDescriptor {
 
   final case class Sequence[K, V, A](config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, List[A]]
 
-  final case class Source[K, V, A](path: K, source: ConfigSource[K, V], propertyType: PropertyType[V, A])
+  final case class Source[K, V, A](source: ConfigSource[K, V], propertyType: PropertyType[V, A])
       extends ConfigDescriptor[K, V, A]
 
   final case class Zip[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
@@ -134,38 +134,56 @@ object ConfigDescriptor {
     g: B => Either[String, A]
   ) extends ConfigDescriptor[K, V, B]
 
-  def bigDecimal(path: String): ConfigDescriptor[String, String, BigDecimal] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigDecimalType) ?? "value of type bigdecimal"
+  val bigDecimal: ConfigDescriptor[String, String, BigDecimal] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.BigDecimalType) ?? "value of type bigdecimal"
 
-  def bigInt(path: String): ConfigDescriptor[String, String, BigInt] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BigIntType) ?? "value of type bigint"
+  def bigDecimal(path: String): ConfigDescriptor[String, String, BigDecimal] = nested(path)(bigDecimal)
 
-  def boolean(path: String): ConfigDescriptor[String, String, Boolean] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.BooleanType) ?? "value of type boolean"
+  val bigInt: ConfigDescriptor[String, String, BigInt] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.BigIntType) ?? "value of type bigint"
 
-  def byte(path: String): ConfigDescriptor[String, String, Byte] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ByteType) ?? "value of type byte"
+  def bigInt(path: String): ConfigDescriptor[String, String, BigInt] = nested(path)(bigInt)
+
+  val boolean: ConfigDescriptor[String, String, Boolean] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.BooleanType) ?? "value of type boolean"
+
+  def boolean(path: String): ConfigDescriptor[String, String, Boolean] = nested(path)(boolean)
+
+  val byte: ConfigDescriptor[String, String, Byte] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.ByteType) ?? "value of type byte"
+
+  def byte(path: String): ConfigDescriptor[String, String, Byte] = nested(path)(byte)
 
   def collectAll[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] =
     sequence(configList)
 
-  def double(path: String): ConfigDescriptor[String, String, Double] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DoubleType) ?? "value of type double"
+  val double: ConfigDescriptor[String, String, Double] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.DoubleType) ?? "value of type double"
 
-  def duration(path: String): ConfigDescriptor[String, String, Duration] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.DurationType) ?? "value of type duration"
+  def double(path: String): ConfigDescriptor[String, String, Double] = nested(path)(double)
 
-  def float(path: String): ConfigDescriptor[String, String, Float] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.FloatType) ?? "value of type float"
+  val duration: ConfigDescriptor[String, String, Duration] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.DurationType) ?? "value of type duration"
 
-  def int(path: String): ConfigDescriptor[String, String, Int] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.IntType) ?? "value of type int"
+  def duration(path: String): ConfigDescriptor[String, String, Duration] = nested(path)(duration)
+
+  val float: ConfigDescriptor[String, String, Float] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.FloatType) ?? "value of type float"
+
+  def float(path: String): ConfigDescriptor[String, String, Float] = nested(path)(float)
+
+  val int: ConfigDescriptor[String, String, Int] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.IntType) ?? "value of type int"
+
+  def int(path: String): ConfigDescriptor[String, String, Int] = nested(path)(int)
 
   def list[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
     ConfigDescriptor.Sequence(desc)
 
-  def long(path: String): ConfigDescriptor[String, String, Long] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.LongType) ?? "value of type long"
+  val long: ConfigDescriptor[String, String, Long] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.LongType) ?? "value of type long"
+
+  def long(path: String): ConfigDescriptor[String, String, Long] = nested(path)(long)
 
   def nested[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
     ConfigDescriptor.Nested(path, desc)
@@ -183,12 +201,18 @@ object ConfigDescriptor {
     )
   }
 
-  def short(path: String): ConfigDescriptor[String, String, Short] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.ShortType) ?? "value of type short"
+  val short: ConfigDescriptor[String, String, Short] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.ShortType) ?? "value of type short"
 
-  def string(path: String): ConfigDescriptor[String, String, String] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.StringType) ?? "value of type string"
+  def short(path: String): ConfigDescriptor[String, String, Short] = nested(path)(short)
 
-  def uri(path: String): ConfigDescriptor[String, String, URI] =
-    ConfigDescriptor.Source(path, ConfigSource.empty, PropertyType.UriType) ?? "value of type uri"
+  val string: ConfigDescriptor[String, String, String] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.StringType) ?? "value of type string"
+
+  def string(path: String): ConfigDescriptor[String, String, String] = nested(path)(string)
+
+  val uri: ConfigDescriptor[String, String, URI] =
+    ConfigDescriptor.Source(ConfigSource.empty, PropertyType.UriType) ?? "value of type uri"
+
+  def uri(path: String): ConfigDescriptor[String, String, URI] = nested(path)(uri)
 }

--- a/core/src/main/scala/zio/config/ConfigDocs.scala
+++ b/core/src/main/scala/zio/config/ConfigDocs.scala
@@ -2,21 +2,14 @@ package zio.config
 
 sealed trait ConfigDocs[+K, +V]
 object ConfigDocs {
-  sealed trait Details[+V] {
-    def sources: Sources
-    def descriptions: List[String]
-  }
-  object Details {
-    final case class Descriptions(sources: Sources, descriptions: List[String]) extends Details[Nothing]
-    final case class DescriptionsWithValue[V](value: Option[V], sources: Sources, descriptions: List[String])
-        extends Details[V]
-  }
+  final case class Leaf[V](sources: Sources, descriptions: List[String], value: Option[V] = None)
+      extends ConfigDocs[Nothing, V]
 
   final case class Sources(list: List[String])
 
   final case object Empty                                                       extends ConfigDocs[Nothing, Nothing]
-  final case class Path[K, V](path: K, details: Details[V])                     extends ConfigDocs[K, V]
   final case class NestedPath[K, V](path: K, docs: ConfigDocs[K, V])            extends ConfigDocs[K, V]
   final case class Both[K, V](left: ConfigDocs[K, V], right: ConfigDocs[K, V])  extends ConfigDocs[K, V]
   final case class OneOf[K, V](left: ConfigDocs[K, V], right: ConfigDocs[K, V]) extends ConfigDocs[K, V]
+  final case class Sequence[K, V](element: List[ConfigDocs[K, V]])              extends ConfigDocs[K, V]
 }

--- a/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
+++ b/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
@@ -2,59 +2,56 @@ package zio.config
 
 private[config] trait ConfigDocsFunctions {
   import ConfigDocs._
-  import ConfigDocs.Details._
 
   final def generateDocs[K, V, A](config: ConfigDescriptor[K, V, A]): ConfigDocs[K, V] = {
     def loop[B](
-      descAcc: Descriptions,
+      sources: Sources,
+      descriptions: List[String],
       config: ConfigDescriptor[K, V, B],
       docs: ConfigDocs[K, V]
     ): ConfigDocs[K, V] =
       config match {
-        case ConfigDescriptor.Source(path, source, _) =>
-          Path(
-            path,
-            Descriptions(Sources(source.sourceDescription ++ descAcc.sources.list), descAcc.descriptions)
-          )
+        case ConfigDescriptor.Source(source, _) =>
+          Leaf(Sources(source.sourceDescription ++ sources.list), descriptions, None)
 
         case ConfigDescriptor.Default(c, _) =>
-          loop(descAcc, c, docs)
+          loop(sources, descriptions, c, docs)
 
         case ConfigDescriptor.Sequence(c) =>
-          loop(descAcc.copy(descriptions = "value of type list" :: descAcc.descriptions), c, docs)
+          ConfigDocs.Sequence(loop(sources, descriptions, c, docs) :: Nil)
 
-        case ConfigDescriptor.Describe(c, description) =>
-          loop(descAcc.copy(descriptions = description :: descAcc.descriptions), c, docs)
+        case ConfigDescriptor.Describe(c, desc) =>
+          loop(sources, desc :: descriptions, c, docs)
 
         case ConfigDescriptor.Optional(c) =>
-          loop(descAcc, c, docs)
+          loop(sources, descriptions, c, docs)
 
         case ConfigDescriptor.Nested(path, c) =>
-          ConfigDocs.NestedPath(path, loop(descAcc, c, docs))
+          ConfigDocs.NestedPath(path, loop(sources, descriptions, c, docs))
 
         case ConfigDescriptor.XmapEither(c, _, _) =>
-          loop(descAcc, c, docs)
+          loop(sources, descriptions, c, docs)
 
         case ConfigDescriptor.Zip(left, right) =>
           ConfigDocs.Both(
-            loop(descAcc, left, docs),
-            loop(descAcc, right, docs)
+            loop(sources, descriptions, left, docs),
+            loop(sources, descriptions, right, docs)
           )
 
         case ConfigDescriptor.OrElseEither(left, right) =>
           ConfigDocs.OneOf(
-            loop(descAcc, left, docs),
-            loop(descAcc, right, docs)
+            loop(sources, descriptions, left, docs),
+            loop(sources, descriptions, right, docs)
           )
 
         case ConfigDescriptor.OrElse(left, right) =>
           ConfigDocs.OneOf(
-            loop(descAcc, left, docs),
-            loop(descAcc, right, docs)
+            loop(sources, descriptions, left, docs),
+            loop(sources, descriptions, right, docs)
           )
       }
 
-    loop(Descriptions(Sources(Nil), Nil), config, Empty)
+    loop(Sources(Nil), Nil, config, Empty)
   }
 
   def generateDocsWithValue[K, V, A](
@@ -63,31 +60,39 @@ private[config] trait ConfigDocsFunctions {
   ): Either[String, ConfigDocs[K, V]] =
     write(config, value)
       .map(tree => {
-        val flattened = tree.flatten
-
-        def loop(c: ConfigDocs[K, V], initialValue: Vector[K]): ConfigDocs[K, V] =
+        def loop(
+          tree: PropertyTree[K, V],
+          flattened: Map[Vector[K], ::[V]],
+          c: ConfigDocs[K, V],
+          initialValue: Vector[K]
+        ): ConfigDocs[K, V] =
           c match {
             case Empty => Empty
 
-            case Path(path, docs) =>
-              val updated: Details[V] =
-                docs match {
-                  case Descriptions(sources, descriptions) =>
-                    DescriptionsWithValue(flattened.get(initialValue :+ path).map(_.head), sources, descriptions)
-                  case a => a
-                }
-              Path(path, updated)
+            case Leaf(sources, descriptions, None) =>
+              Leaf(sources, descriptions, flattened.get(initialValue).flatMap(_.headOption))
+
+            case a: Leaf[V] => a
 
             case NestedPath(path, docs) =>
-              NestedPath(path, loop(docs, initialValue :+ path))
+              NestedPath(path, loop(tree, flattened, docs, initialValue :+ path))
 
             case Both(left, right) =>
-              Both(loop(left, initialValue), loop(right, initialValue))
+              Both(loop(tree, flattened, left, initialValue), loop(tree, flattened, right, initialValue))
 
             case OneOf(left, right) =>
-              OneOf(loop(left, initialValue), loop(right, initialValue))
+              OneOf(loop(tree, flattened, left, initialValue), loop(tree, flattened, right, initialValue))
+
+            case Sequence(element :: Nil) =>
+              tree.getPath(initialValue.toList) match {
+                case PropertyTree.Sequence(value) if value.nonEmpty =>
+                  Sequence(value.map(t => loop(t, t.flatten, element, Vector.empty)))
+                case _ => Sequence(loop(tree, flattened, element, initialValue) :: Nil)
+              }
+
+            case s: Sequence[K, V] => s
           }
 
-        loop(generateDocs(config), Vector.empty)
+        loop(tree, tree.flatten, generateDocs(config), Vector.empty)
       })
 }

--- a/core/src/main/scala/zio/config/ConfigSource.scala
+++ b/core/src/main/scala/zio/config/ConfigSource.scala
@@ -66,9 +66,9 @@ object ConfigSource {
    *
    *    val credentials = (string("username") |@| string("password"))(Credentials.apply, Credentials.unapply)
    *
-   *    final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String, users: List[String])
+   *    final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String], users: List[String])
    *
-   *    (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions") |@| list(string("user"))(Config.apply, Config.unapply)
+   *    (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions")) |@| list(string("user")))(Config.apply, Config.unapply)
    *
    *    // res0 Config(Credentials(1, hi), Credentials(3, 10), List(111, 122), List(k1, k2))
    *

--- a/core/src/main/scala/zio/config/WriteFunctions.scala
+++ b/core/src/main/scala/zio/config/WriteFunctions.scala
@@ -5,8 +5,8 @@ private[config] trait WriteFunctions {
   final def write[K, V, A](config: ConfigDescriptor[K, V, A], a: A): Either[String, PropertyTree[K, V]] = {
     def go[B](config: ConfigDescriptor[K, V, B], b: B): Either[String, PropertyTree[K, V]] =
       config match {
-        case ConfigDescriptor.Source(path, _, propertyType) =>
-          Right(PropertyTree.Record(Map(path -> PropertyTree.Leaf(propertyType.write(b)))))
+        case ConfigDescriptor.Source(_, propertyType) =>
+          Right(PropertyTree.Leaf(propertyType.write(b)))
 
         case ConfigDescriptor.Describe(c, _) =>
           go(c, b)

--- a/core/src/test/scala/zio/config/GenerateDocsTest.scala
+++ b/core/src/test/scala/zio/config/GenerateDocsTest.scala
@@ -1,8 +1,7 @@
 package zio.config
 
 import zio.config.ConfigDescriptor.{ int, nested, string }
-import zio.config.ConfigDocs.Details.{ Descriptions, DescriptionsWithValue }
-import zio.config.ConfigDocs.{ Both, NestedPath, Path, Sources }
+import zio.config.ConfigDocs.{ Both, Leaf, NestedPath, Sources }
 import zio.config.GenerateDocsTestUtils._
 import zio.config.helpers._
 import zio.random.Random
@@ -73,9 +72,9 @@ object GenerateDocsTestUtils {
     def docs: ConfigDocs[String, String] =
       Both(
         Both(
-          Path(
+          NestedPath(
             keys.secret,
-            Descriptions(
+            Leaf(
               Sources(List("test")),
               List("value of type string", "optional value", "Application secret")
             )
@@ -83,16 +82,16 @@ object GenerateDocsTestUtils {
           NestedPath(
             keys.credentials,
             Both(
-              Path(
+              NestedPath(
                 keys.user,
-                Descriptions(
+                Leaf(
                   Sources(List("test")),
                   List("value of type string", "Example: ZioUser", "Credentials")
                 )
               ),
-              Path(
+              NestedPath(
                 keys.password,
-                Descriptions(
+                Leaf(
                   Sources(List("test")),
                   List("value of type string", "Example: ZioPass", "Credentials")
                 )
@@ -103,16 +102,16 @@ object GenerateDocsTestUtils {
         NestedPath(
           keys.database,
           Both(
-            Path(
+            NestedPath(
               keys.port,
-              Descriptions(
+              Leaf(
                 Sources(List("test")),
                 List("value of type int", "Example: 8088", "Database")
               )
             ),
-            Path(
+            NestedPath(
               keys.url,
-              Descriptions(
+              Leaf(
                 Sources(List("test")),
                 List("value of type string", "Example: abc.com", "Database")
               )
@@ -125,31 +124,31 @@ object GenerateDocsTestUtils {
       Right(
         Both(
           Both(
-            Path(
+            NestedPath(
               keys.secret,
-              DescriptionsWithValue(
-                value.secret,
+              Leaf(
                 Sources(List("test")),
-                List("value of type string", "optional value", "Application secret")
+                List("value of type string", "optional value", "Application secret"),
+                value.secret
               )
             ),
             NestedPath(
               keys.credentials,
               Both(
-                Path(
+                NestedPath(
                   keys.user,
-                  DescriptionsWithValue(
-                    Some(value.credentials.user),
+                  Leaf(
                     Sources(List("test")),
-                    List("value of type string", "Example: ZioUser", "Credentials")
+                    List("value of type string", "Example: ZioUser", "Credentials"),
+                    Some(value.credentials.user)
                   )
                 ),
-                Path(
+                NestedPath(
                   keys.password,
-                  DescriptionsWithValue(
-                    Some(value.credentials.password),
+                  Leaf(
                     Sources(List("test")),
-                    List("value of type string", "Example: ZioPass", "Credentials")
+                    List("value of type string", "Example: ZioPass", "Credentials"),
+                    Some(value.credentials.password)
                   )
                 )
               )
@@ -158,20 +157,20 @@ object GenerateDocsTestUtils {
           NestedPath(
             keys.database,
             Both(
-              Path(
+              NestedPath(
                 keys.port,
-                DescriptionsWithValue(
-                  Some(value.database.port).map(_.toString),
+                Leaf(
                   Sources(List("test")),
-                  List("value of type int", "Example: 8088", "Database")
+                  List("value of type int", "Example: 8088", "Database"),
+                  Some(value.database.port).map(_.toString)
                 )
               ),
-              Path(
+              NestedPath(
                 keys.url,
-                DescriptionsWithValue(
-                  Some(value.database.url),
+                Leaf(
                   Sources(List("test")),
-                  List("value of type string", "Example: abc.com", "Database")
+                  List("value of type string", "Example: abc.com", "Database"),
+                  Some(value.database.url)
                 )
               )
             )

--- a/docs/usingconfigdescriptor/index.md
+++ b/docs/usingconfigdescriptor/index.md
@@ -21,7 +21,7 @@ You should be familiar with reading config from various sources, given a  config
 import zio.IO
 import zio.config._, ConfigDescriptor._
 import zio.config.PropertyTree._
-import zio.config.ConfigDocs._, ConfigDocs.Details._
+import zio.config.ConfigDocs.{Leaf => _, _}
 
 ```
 
@@ -126,19 +126,19 @@ To generate the documentation of the config, call `generateDocs`.
      NestedPath(
        "south",
        Both(
-         Path("connection", Descriptions(Sources(List("constant")), List("value of type string", "South details"))),
-         Path("port", Descriptions(Sources(List("constant")), List("value of type int", "South details")))
+         NestedPath("connection", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "South details"))),
+         NestedPath("port", ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "South details")))
        )
      ),
      NestedPath(
        "east",
        Both(
-         Path("connection", Descriptions(Sources(List("constant")), List("value of type string", "East details"))),
-         Path("port", Descriptions(Sources(List("constant")), List("value of type int", "East details")))
+         NestedPath("connection", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "East details"))),
+         NestedPath("port", ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "East details")))
        )
      )
    ),
-   Path("appName", Descriptions(Sources(List("constant")), List("value of type string")))
+   NestedPath("appName", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string")))
  )
 ```
 
@@ -169,31 +169,31 @@ Right(
       NestedPath(
         "south",
         Both(
-          Path(
+          NestedPath(
             "connection",
-            DescriptionsWithValue(Some("abc.com"), Sources(List("constant")), List("value of type string", "South details"))
+            ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "South details"), Some("abc.com"))
           ),
-          Path(
+          NestedPath(
             "port",
-            DescriptionsWithValue(Some("8111"), Sources(List("constant")), List("value of type int", "South details"))
+            ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "South details"), Some("8111"))
           )
         )
       ),
       NestedPath(
         "east",
         Both(
-          Path(
+          NestedPath(
             "connection",
-            DescriptionsWithValue(Some("xyz.com"), Sources(List("constant")), List("value of type string", "East details"))
+            ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "East details"), Some("xyz.com"))
           ),
-          Path(
+          NestedPath(
             "port",
-            DescriptionsWithValue(Some("8888"), Sources(List("constant")), List("value of type int", "East details"))
+            ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "East details"), Some("8888"))
           )
         )
       )
     ),
-    Path("appName", DescriptionsWithValue(Some("myApp"), Sources(List("constant")), List("value of type string")))
+    NestedPath("appName", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string"), Some("myApp")))
   )
 )
 ```

--- a/examples/src/main/scala/zio/config/examples/DefaultValueExample.scala
+++ b/examples/src/main/scala/zio/config/examples/DefaultValueExample.scala
@@ -1,12 +1,9 @@
 package zio.config.examples
 
+import zio.config.ConfigDescriptor._
+import zio.config.ConfigDocs._
+import zio.config.ConfigSource._
 import zio.config._
-import ConfigDescriptor._
-import zio.config.ConfigDocs
-import ConfigDocs._
-import Details._
-import zio.config.ConfigDocs.Path
-import ConfigSource._
 
 object DefaultValueExample extends App {
   final case class PgmConfig(a: String, b: Either[String, Int])
@@ -32,21 +29,21 @@ object DefaultValueExample extends App {
   assert(
     generateDocs(confEx) ==
       Both(
-        Path(
+        NestedPath(
           "HELLO",
-          Descriptions(
+          Leaf(
             Sources(List(ConfigSource.SystemEnvironment)),
             List("value of type string", "default value: xyz")
           )
         ),
         OneOf(
-          Path(
+          NestedPath(
             "SOMETHING",
-            Descriptions(Sources(List(ConfigSource.SystemEnvironment)), List("value of type string"))
+            Leaf(Sources(List(ConfigSource.SystemEnvironment)), List("value of type string"))
           ),
-          Path(
+          NestedPath(
             "PORT",
-            Descriptions(
+            Leaf(
               Sources(List(ConfigSource.SystemEnvironment)),
               List("value of type int", "default value: 1")
             )
@@ -59,25 +56,25 @@ object DefaultValueExample extends App {
     generateDocsWithValue(confEx, expected) ==
       Right(
         Both(
-          Path(
+          NestedPath(
             "HELLO",
-            DescriptionsWithValue(
-              Some("xyz"),
+            Leaf(
               Sources(List(SystemEnvironment)),
-              List("value of type string", "default value: xyz")
+              List("value of type string", "default value: xyz"),
+              Some("xyz")
             )
           ),
           OneOf(
-            Path(
+            NestedPath(
               "SOMETHING",
-              DescriptionsWithValue(None, Sources(List(SystemEnvironment)), List("value of type string"))
+              Leaf(Sources(List(SystemEnvironment)), List("value of type string"), None)
             ),
-            Path(
+            NestedPath(
               "PORT",
-              DescriptionsWithValue(
-                Some("1"),
+              Leaf(
                 Sources(List(SystemEnvironment)),
-                List("value of type int", "default value: 1")
+                List("value of type int", "default value: 1"),
+                Some("1")
               )
             )
           )

--- a/examples/src/main/scala/zio/config/examples/DocsExample.scala
+++ b/examples/src/main/scala/zio/config/examples/DocsExample.scala
@@ -1,8 +1,7 @@
 package zio.config.examples
 
 import zio.config.ConfigDescriptor._
-import zio.config.ConfigDocs.Details._
-import zio.config.ConfigDocs.{ Path, _ }
+import zio.config.ConfigDocs._
 import zio.config._
 
 object DocsExample extends App {
@@ -16,13 +15,13 @@ object DocsExample extends App {
   assert(
     generateDocs(config) ==
       Both(
-        Path(
+        NestedPath(
           "PORT",
-          Descriptions(Sources(Nil), List("value of type int", "Example: 8088", "Database related"))
+          Leaf(Sources(Nil), List("value of type int", "Example: 8088", "Database related"))
         ),
-        Path(
+        NestedPath(
           "URL",
-          Descriptions(
+          Leaf(
             Sources(Nil),
             List("value of type string", "optional value", "Example: abc.com", "Database related")
           )
@@ -34,20 +33,20 @@ object DocsExample extends App {
     generateDocsWithValue(config, Database(1, Some("value"))) ==
       Right(
         Both(
-          Path(
+          NestedPath(
             "PORT",
-            DescriptionsWithValue(
-              Some("1"),
+            Leaf(
               Sources(Nil),
-              List("value of type int", "Example: 8088", "Database related")
+              List("value of type int", "Example: 8088", "Database related"),
+              Some("1")
             )
           ),
-          Path(
+          NestedPath(
             "URL",
-            DescriptionsWithValue(
-              Some("value"),
+            Leaf(
               Sources(Nil),
-              List("value of type string", "optional value", "Example: abc.com", "Database related")
+              List("value of type string", "optional value", "Example: abc.com", "Database related"),
+              Some("value")
             )
           )
         )

--- a/examples/src/main/scala/zio/config/examples/NestedConfigExample.scala
+++ b/examples/src/main/scala/zio/config/examples/NestedConfigExample.scala
@@ -1,8 +1,8 @@
 package zio.config.examples
 
-import zio.config._
-import ConfigDescriptor._, zio.config.ConfigDocs.Details._
+import zio.config.ConfigDescriptor._
 import zio.config.ConfigDocs._
+import zio.config._
 
 object NestedConfigExample extends App {
 
@@ -43,25 +43,25 @@ object NestedConfigExample extends App {
           NestedPath(
             "south",
             Both(
-              Path(
+              NestedPath(
                 "connection",
-                Descriptions(Sources(Nil), List("value of type string", "South details"))
+                Leaf(Sources(Nil), List("value of type string", "South details"))
               ),
-              Path("port", Descriptions(Sources(Nil), List("value of type int", "South details")))
+              NestedPath("port", Leaf(Sources(Nil), List("value of type int", "South details")))
             )
           ),
           NestedPath(
             "east",
             Both(
-              Path(
+              NestedPath(
                 "connection",
-                Descriptions(Sources(Nil), List("value of type string", "East details"))
+                Leaf(Sources(Nil), List("value of type string", "East details"))
               ),
-              Path("port", Descriptions(Sources(Nil), List("value of type int", "East details")))
+              NestedPath("port", Leaf(Sources(Nil), List("value of type int", "East details")))
             )
           )
         ),
-        Path("appName", Descriptions(Sources(Nil), List("value of type string")))
+        NestedPath("appName", Leaf(Sources(Nil), List("value of type string")))
       )
   )
 
@@ -74,20 +74,20 @@ object NestedConfigExample extends App {
             NestedPath(
               "south",
               Both(
-                Path(
+                NestedPath(
                   "connection",
-                  DescriptionsWithValue(
-                    Some("abc.com"),
+                  Leaf(
                     Sources(Nil),
-                    List("value of type string", "South details")
+                    List("value of type string", "South details"),
+                    Some("abc.com")
                   )
                 ),
-                Path(
+                NestedPath(
                   "port",
-                  DescriptionsWithValue(
-                    Some("8111"),
+                  Leaf(
                     Sources(Nil),
-                    List("value of type int", "South details")
+                    List("value of type int", "South details"),
+                    Some("8111")
                   )
                 )
               )
@@ -95,28 +95,28 @@ object NestedConfigExample extends App {
             NestedPath(
               "east",
               Both(
-                Path(
+                NestedPath(
                   "connection",
-                  DescriptionsWithValue(
-                    Some("xyz.com"),
+                  Leaf(
                     Sources(Nil),
-                    List("value of type string", "East details")
+                    List("value of type string", "East details"),
+                    Some("xyz.com")
                   )
                 ),
-                Path(
+                NestedPath(
                   "port",
-                  DescriptionsWithValue(
-                    Some("8888"),
+                  Leaf(
                     Sources(Nil),
-                    List("value of type int", "East details")
+                    List("value of type int", "East details"),
+                    Some("8888")
                   )
                 )
               )
             )
           ),
-          Path(
+          NestedPath(
             "appName",
-            DescriptionsWithValue(Some("myApp"), Sources(Nil), List("value of type string"))
+            Leaf(Sources(Nil), List("value of type string"), Some("myApp"))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ReadWriteReportExample.scala
+++ b/examples/src/main/scala/zio/config/examples/ReadWriteReportExample.scala
@@ -1,9 +1,8 @@
 package zio.config.examples
 
-import zio.config._
-import ConfigDescriptor._
-import zio.config.ConfigDocs.Details._
+import zio.config.ConfigDescriptor._
 import zio.config.ConfigDocs._
+import zio.config._
 
 object ReadWriteReportExample extends App {
 
@@ -58,11 +57,18 @@ object ReadWriteReportExample extends App {
       )
   )
 
-  import PropertyTree._
-
   assert(
     write(config, expected) ==
-      Right(Record(Map("usr" -> Leaf("v1"), "pwd" -> Leaf("v2"), "xyz" -> Leaf("v3"), "abc" -> Leaf("1"))))
+      Right(
+        PropertyTree.Record(
+          Map(
+            "usr" -> PropertyTree.Leaf("v1"),
+            "pwd" -> PropertyTree.Leaf("v2"),
+            "xyz" -> PropertyTree.Leaf("v3"),
+            "abc" -> PropertyTree.Leaf("1")
+          )
+        )
+      )
   )
 
   assert(
@@ -71,48 +77,48 @@ object ReadWriteReportExample extends App {
         Both(
           Both(
             Both(
-              Path(
+              NestedPath(
                 "usr",
-                Descriptions(
+                Leaf(
                   Sources(List("constant")),
                   List("value of type string", "Example: some-user", "Prod Config")
                 )
               ),
-              Path(
+              NestedPath(
                 "pwd",
-                Descriptions(
+                Leaf(
                   Sources(List("constant")),
                   List("value of type string", "optional value", "sec", "Prod Config")
                 )
               )
             ),
-            Path(
+            NestedPath(
               "jhi",
-              Descriptions(
+              Leaf(
                 Sources(List("constant")),
                 List("value of type string", "optional value", "Ex: ghi", "Prod Config")
               )
             )
           ),
           Both(
-            Path(
+            NestedPath(
               "xyz",
-              Descriptions(
+              Leaf(
                 Sources(List("constant")),
                 List("value of type string", "optional value", "Ex: ha", "Prod Config")
               )
             ),
             OneOf(
-              Path(
+              NestedPath(
                 "abc",
-                Descriptions(
+                Leaf(
                   Sources(List("constant")),
                   List("value of type int", "optional value", "Ex: ha", "Prod Config")
                 )
               ),
-              Path(
+              NestedPath(
                 "def",
-                Descriptions(
+                Leaf(
                   Sources(List("constant")),
                   List("value of type string", "optional value", "Ex: ha", "Prod Config")
                 )
@@ -121,13 +127,13 @@ object ReadWriteReportExample extends App {
           )
         ),
         Both(
-          Path(
+          NestedPath(
             "auth_token",
-            Descriptions(Sources(List("constant")), List("value of type string", "Prod Config"))
+            Leaf(Sources(List("constant")), List("value of type string", "Prod Config"))
           ),
-          Path(
+          NestedPath(
             "clientid",
-            Descriptions(Sources(List("constant")), List("value of type string", "Prod Config"))
+            Leaf(Sources(List("constant")), List("value of type string", "Prod Config"))
           )
         )
       )
@@ -140,54 +146,52 @@ object ReadWriteReportExample extends App {
           Both(
             Both(
               Both(
-                Path(
+                NestedPath(
                   "usr",
-                  DescriptionsWithValue(
-                    Some("v1"),
+                  Leaf(
                     Sources(List("constant")),
-                    List("value of type string", "Example: some-user", "Prod Config")
+                    List("value of type string", "Example: some-user", "Prod Config"),
+                    Some("v1")
                   )
                 ),
-                Path(
+                NestedPath(
                   "pwd",
-                  DescriptionsWithValue(
-                    Some("v2"),
+                  Leaf(
                     Sources(List("constant")),
-                    List("value of type string", "optional value", "sec", "Prod Config")
+                    List("value of type string", "optional value", "sec", "Prod Config"),
+                    Some("v2")
                   )
                 )
               ),
-              Path(
+              NestedPath(
                 "jhi",
-                DescriptionsWithValue(
-                  None,
+                Leaf(
                   Sources(List("constant")),
                   List("value of type string", "optional value", "Ex: ghi", "Prod Config")
                 )
               )
             ),
             Both(
-              Path(
+              NestedPath(
                 "xyz",
-                DescriptionsWithValue(
-                  Some("v3"),
+                Leaf(
                   Sources(List("constant")),
-                  List("value of type string", "optional value", "Ex: ha", "Prod Config")
+                  List("value of type string", "optional value", "Ex: ha", "Prod Config"),
+                  Some("v3")
                 )
               ),
               OneOf(
-                Path(
+                NestedPath(
                   "abc",
-                  DescriptionsWithValue(
-                    Some("1"),
+                  Leaf(
                     Sources(List("constant")),
-                    List("value of type int", "optional value", "Ex: ha", "Prod Config")
+                    List("value of type int", "optional value", "Ex: ha", "Prod Config"),
+                    Some("1")
                   )
                 ),
-                Path(
+                NestedPath(
                   "def",
-                  DescriptionsWithValue(
-                    None,
+                  Leaf(
                     Sources(List("constant")),
                     List("value of type string", "optional value", "Ex: ha", "Prod Config")
                   )
@@ -196,18 +200,16 @@ object ReadWriteReportExample extends App {
             )
           ),
           Both(
-            Path(
+            NestedPath(
               "auth_token",
-              DescriptionsWithValue(
-                None,
+              Leaf(
                 Sources(List("constant")),
                 List("value of type string", "Prod Config")
               )
             ),
-            Path(
+            NestedPath(
               "clientid",
-              DescriptionsWithValue(
-                None,
+              Leaf(
                 Sources(List("constant")),
                 List("value of type string", "Prod Config")
               )

--- a/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
@@ -103,7 +103,7 @@ object DeriveConfigDescriptor {
         parentClass: Option[String]
       ): ConfigDescriptor[String, String, T] =
         path.fold(
-          string("").xmapEither[T](
+          string.xmapEither[T](
             _ => Left("unable to fetch the primitive without a path"),
             (_: T) => Left("unable to write the primitive back to a config source without a path")
           )
@@ -166,7 +166,7 @@ object DeriveConfigDescriptor {
               case Some(parentClass) => string(parentClass.toLowerCase())
 
               case None =>
-                string("").xmapEither[String](
+                string.xmapEither[String](
                   _ =>
                     Left(
                       s"Cannot create the case-object ${caseClass.typeName.short} since it is not part of a coproduct (ie. extends sealed trait)"

--- a/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
+++ b/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
@@ -4,11 +4,11 @@ import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection._
 import eu.timepit.refined.numeric._
-import zio.{ ZIO }
+import zio.ZIO
 import zio.config.ConfigDescriptor._
+import zio.config._
 import zio.config.helpers._
 import zio.config.refined.RefinedReadWriteRoundtripTestUtils._
-import zio.config._
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._


### PR DESCRIPTION
Allow ConfigDescriptor without path
Add ConfigDocs.Sequence

`string(path)` becomes `string.at(path)`
`list(string(path))` -> `list(string).at(path)`