### PR TITLE
Fix empty list processing

### DIFF
--- a/core/src/main/scala/zio/config/Config.scala
+++ b/core/src/main/scala/zio/config/Config.scala
@@ -36,7 +36,7 @@ object Config {
    *
    *  final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String], users: List[String])
    *
-   *  (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions")) |@| list(string("user")))(Config.apply, Config.unapply)
+   *  (nested("db") { credentials } |@| nested("vault") { credentials } |@| list("regions")(string) |@| list("user")(string))(Config.apply, Config.unapply)
    *
    *  // res0 Config(Credentials(1, hi), Credentials(3, 10), List(111, 122), List(k1, k2))
    *

--- a/core/src/main/scala/zio/config/ConfigDescriptor.scala
+++ b/core/src/main/scala/zio/config/ConfigDescriptor.scala
@@ -47,7 +47,7 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
     def loop[B](config: ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, B] = config match {
       case Source(source, propertyType) => Source(source, propertyType)
       case Nested(path, conf)           => Nested(f(path), loop(conf))
-      case Sequence(conf)               => Sequence(loop(conf))
+      case Sequence(source, conf)       => Sequence(source, loop(conf))
       case Describe(config, message)    => Describe(loop(config), message)
       case Default(value, value2)       => Default(loop(value), value2)
       case Optional(config)             => Optional(loop(config))
@@ -77,7 +77,7 @@ sealed trait ConfigDescriptor[K, V, A] { self =>
     def loop[B](config: ConfigDescriptor[K, V, B]): ConfigDescriptor[K, V, B] = config match {
       case Source(source, propertyType) => Source(f(source), propertyType)
       case Nested(path, conf)           => Nested(path, loop(conf))
-      case Sequence(conf)               => Sequence(loop(conf))
+      case Sequence(source, conf)       => Sequence(f(source), loop(conf))
       case Describe(config, message)    => Describe(loop(config), message)
       case Default(value, value2)       => Default(loop(value), value2)
       case Optional(config)             => Optional(loop(config))
@@ -122,7 +122,8 @@ object ConfigDescriptor {
   final case class OrElseEither[K, V, A, B](left: ConfigDescriptor[K, V, A], right: ConfigDescriptor[K, V, B])
       extends ConfigDescriptor[K, V, Either[A, B]]
 
-  final case class Sequence[K, V, A](config: ConfigDescriptor[K, V, A]) extends ConfigDescriptor[K, V, List[A]]
+  final case class Sequence[K, V, A](source: ConfigSource[K, V], config: ConfigDescriptor[K, V, A])
+      extends ConfigDescriptor[K, V, List[A]]
 
   final case class Source[K, V, A](source: ConfigSource[K, V], propertyType: PropertyType[V, A])
       extends ConfigDescriptor[K, V, A]
@@ -177,6 +178,10 @@ object ConfigDescriptor {
   val float: ConfigDescriptor[String, String, Float] =
     ConfigDescriptor.Source(ConfigSource.empty, PropertyType.FloatType) ?? "value of type float"
 
+  def first[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]) =
+    list(path)(desc)
+      .xmapEither[A](_.headOption.fold[Either[String, A]](Left("Element is missing"))(Right(_)), v => Right(v :: Nil))
+
   def float(path: String): ConfigDescriptor[String, String, Float] = nested(path)(float)
 
   val int: ConfigDescriptor[String, String, Int] =
@@ -184,8 +189,55 @@ object ConfigDescriptor {
 
   def int(path: String): ConfigDescriptor[String, String, Int] = nested(path)(int)
 
-  def list[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
-    ConfigDescriptor.Sequence(desc)
+  /**
+   * Leaks out path in simple cases, i.e.
+   * `list(string(path))` == `list(path)(string)` == `nested(path)(listOrSingle(string))`
+   *
+   * `nested("a")(list(string("b")))` describes configuration `{a: { b: ["s1", "s2"] }}`
+   *
+   * Allows scalar value instead of list
+   * */
+  def list[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] = {
+    def extractPath(cfg: ConfigDescriptor[K, V, A]): Option[(K, ConfigDescriptor[K, V, A])] = cfg match {
+      case Describe(config, message) =>
+        extractPath(config).map { case (path, inner) => (path, Describe(inner, message)) }
+      case Nested(path, config) => Some((path, config))
+      case _                    => None
+    }
+
+    extractPath(desc) match {
+      case Some((path, inner)) => list(path)(inner)
+      case None                => listOrSingle(desc)
+    }
+  }
+
+  /**
+   * Keeps inner description intact.
+   *
+   * Allows scalar value instead of list
+   * */
+  def list[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
+    nested(path)(listOrSingle(desc))
+
+  /**
+   * Keeps inner description intact.
+   *
+   * `nested("a")(listOrSingle(string("b")))` describes configuration `{a: [{b: "s1"}, {b: "s2"}]}`
+   *
+   * Allows scalar value instead of list
+   * */
+  def listOrSingle[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
+    listStrict(desc).orElse(desc(_ :: Nil, _.headOption))
+
+  /**
+   * Keeps inner description intact.
+   *
+   * `nested("a")(strictList(string("b")))` describes configuration `{a: [{b: "s1"}, {b: "s2"}]}`
+   *
+   * Rejects scalar value in place of list
+   * */
+  def listStrict[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] =
+    ConfigDescriptor.Sequence(ConfigSource.empty, desc)
 
   val long: ConfigDescriptor[String, String, Long] =
     ConfigDescriptor.Source(ConfigSource.empty, PropertyType.LongType) ?? "value of type long"

--- a/core/src/main/scala/zio/config/ConfigDocs.scala
+++ b/core/src/main/scala/zio/config/ConfigDocs.scala
@@ -5,7 +5,7 @@ object ConfigDocs {
   final case class Leaf[V](sources: Sources, descriptions: List[String], value: Option[V] = None)
       extends ConfigDocs[Nothing, V]
 
-  final case class Sources(list: List[String])
+  final case class Sources(set: Set[String])
 
   final case object Empty                                                       extends ConfigDocs[Nothing, Nothing]
   final case class NestedPath[K, V](path: K, docs: ConfigDocs[K, V])            extends ConfigDocs[K, V]

--- a/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
+++ b/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
@@ -12,13 +12,13 @@ private[config] trait ConfigDocsFunctions {
     ): ConfigDocs[K, V] =
       config match {
         case ConfigDescriptor.Source(source, _) =>
-          Leaf(Sources(source.sourceDescription ++ sources.list), descriptions, None)
+          Leaf(Sources(source.sourceDescription ++ sources.set), descriptions, None)
 
         case ConfigDescriptor.Default(c, _) =>
           loop(sources, descriptions, c, docs)
 
         case ConfigDescriptor.Sequence(source, c) =>
-          ConfigDocs.Sequence(loop(Sources(source.sourceDescription ++ sources.list), descriptions, c, docs) :: Nil)
+          ConfigDocs.Sequence(loop(Sources(source.sourceDescription ++ sources.set), descriptions, c, docs) :: Nil)
 
         case ConfigDescriptor.Describe(c, desc) =>
           loop(sources, desc :: descriptions, c, docs)
@@ -51,7 +51,7 @@ private[config] trait ConfigDocsFunctions {
           )
       }
 
-    loop(Sources(Nil), Nil, config, Empty)
+    loop(Sources(Set.empty), Nil, config, Empty)
   }
 
   def generateDocsWithValue[K, V, A](

--- a/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
+++ b/core/src/main/scala/zio/config/ConfigDocsFunctions.scala
@@ -17,8 +17,8 @@ private[config] trait ConfigDocsFunctions {
         case ConfigDescriptor.Default(c, _) =>
           loop(sources, descriptions, c, docs)
 
-        case ConfigDescriptor.Sequence(c) =>
-          ConfigDocs.Sequence(loop(sources, descriptions, c, docs) :: Nil)
+        case ConfigDescriptor.Sequence(source, c) =>
+          ConfigDocs.Sequence(loop(Sources(source.sourceDescription ++ sources.list), descriptions, c, docs) :: Nil)
 
         case ConfigDescriptor.Describe(c, desc) =>
           loop(sources, desc :: descriptions, c, docs)

--- a/core/src/main/scala/zio/config/ConfigSource.scala
+++ b/core/src/main/scala/zio/config/ConfigSource.scala
@@ -78,7 +78,7 @@ object ConfigSource {
    *
    *    final case class Config(databaseCredentials: Credentials, vaultCredentials: Credentials, regions: List[String], users: List[String])
    *
-   *    (nested("db") { credentials } |@| nested("vault") { credentials } |@| list(string("regions")) |@| list(string("user")))(Config.apply, Config.unapply)
+   *    (nested("db") { credentials } |@| nested("vault") { credentials } |@| list("regions")(string) |@| list("user")(string))(Config.apply, Config.unapply)
    *
    *    // res0 Config(Credentials(1, hi), Credentials(3, 10), List(111, 122), List(k1, k2))
    *

--- a/core/src/main/scala/zio/config/ConfigSource.scala
+++ b/core/src/main/scala/zio/config/ConfigSource.scala
@@ -190,9 +190,11 @@ object ConfigSource {
     }
 
     mergeAll(
-      PropertyTree
-        .fromStringMap(mapString, keyDelimiter, valueDelimiter)
-        .map(tree => fromPropertyTree(tree, source))
+      unwrapSingletonLists(
+        dropEmpty(
+          PropertyTree.fromStringMap(mapString, keyDelimiter, valueDelimiter)
+        )
+      ).map(tree => fromPropertyTree(tree, source))
     )
   }
 

--- a/core/src/main/scala/zio/config/PropertyTree.scala
+++ b/core/src/main/scala/zio/config/PropertyTree.scala
@@ -297,7 +297,7 @@ object PropertyTree {
     mergeAll(map.toList.map(tuple => unflatten(tuple._1.toList, tuple._2)))
 
   def mergeAll[K, V](list: List[PropertyTree[K, V]]): List[PropertyTree[K, V]] = list.reverse match {
-    case Nil => PropertyTree.empty :: Nil
+    case Nil => Nil
     case head :: tail =>
       tail.foldLeft(List(head)) {
         case (acc, tree) => acc.flatMap(tree0 => tree.merge(tree0))

--- a/core/src/main/scala/zio/config/ReadError.scala
+++ b/core/src/main/scala/zio/config/ReadError.scala
@@ -9,23 +9,6 @@ sealed trait ReadError[A] extends Exception { self =>
     case ReadError.AndErrors(list)                => s"AndErrors(${list.map(_.toString)}"
   }
 
-  def atKey(key: A): ReadError[A] =
-    self match {
-      case ReadError.MissingValue(path)             => ReadError.MissingValue(path :+ Right(key))
-      case ReadError.FormatError(path, message)     => ReadError.FormatError(path :+ Right(key), message)
-      case ReadError.ConversionError(path, message) => ReadError.ConversionError(path :+ Right(key), message)
-      case ReadError.OrErrors(list)                 => ReadError.OrErrors(list.map(_.atKey(key)))
-      case ReadError.AndErrors(list)                => ReadError.AndErrors(list.map(_.atKey(key)))
-    }
-  def atIndex(index: Int): ReadError[A] =
-    self match {
-      case ReadError.MissingValue(path)             => ReadError.MissingValue(path :+ Left(index))
-      case ReadError.FormatError(path, message)     => ReadError.FormatError(path :+ Left(index), message)
-      case ReadError.ConversionError(path, message) => ReadError.ConversionError(path :+ Left(index), message)
-      case ReadError.OrErrors(list)                 => ReadError.OrErrors(list.map(_.atIndex(index)))
-      case ReadError.AndErrors(list)                => ReadError.AndErrors(list.map(_.atIndex(index)))
-    }
-
   def size: Int =
     self match {
       case ReadError.MissingValue(_)       => 1
@@ -37,9 +20,13 @@ sealed trait ReadError[A] extends Exception { self =>
 }
 
 object ReadError {
-  final case class MissingValue[A](path: Vector[Either[Int, A]])                     extends ReadError[A]
-  final case class FormatError[A](path: Vector[Either[Int, A]], message: String)     extends ReadError[A]
-  final case class ConversionError[A](path: Vector[Either[Int, A]], message: String) extends ReadError[A]
-  final case class OrErrors[A](list: List[ReadError[A]])                             extends ReadError[A]
-  final case class AndErrors[A](list: List[ReadError[A]])                            extends ReadError[A]
+  sealed trait Step[+K]
+  case class KeyStep[+K](key: K)   extends Step[K]
+  case class IndexStep(index: Int) extends Step[Nothing]
+
+  final case class MissingValue[A](path: List[Step[A]])                     extends ReadError[A]
+  final case class FormatError[A](path: List[Step[A]], message: String)     extends ReadError[A]
+  final case class ConversionError[A](path: List[Step[A]], message: String) extends ReadError[A]
+  final case class OrErrors[A](list: List[ReadError[A]])                    extends ReadError[A]
+  final case class AndErrors[A](list: List[ReadError[A]])                   extends ReadError[A]
 }

--- a/core/src/main/scala/zio/config/ReadError.scala
+++ b/core/src/main/scala/zio/config/ReadError.scala
@@ -21,8 +21,10 @@ sealed trait ReadError[A] extends Exception { self =>
 
 object ReadError {
   sealed trait Step[+K]
-  case class KeyStep[+K](key: K)   extends Step[K]
-  case class IndexStep(index: Int) extends Step[Nothing]
+  object Step {
+    final case class Key[+K](key: K)   extends Step[K]
+    final case class Index(index: Int) extends Step[Nothing]
+  }
 
   final case class MissingValue[A](path: List[Step[A]])                     extends ReadError[A]
   final case class FormatError[A](path: List[Step[A]], message: String)     extends ReadError[A]

--- a/core/src/main/scala/zio/config/ReadFunctions.scala
+++ b/core/src/main/scala/zio/config/ReadFunctions.scala
@@ -1,230 +1,131 @@
 package zio.config
 
 import zio.config.ConfigDescriptor._
-import zio.config.ReadError.{ AndErrors, OrErrors }
+import zio.config.ReadError.{ AndErrors, IndexStep, KeyStep, OrErrors, Step }
 import zio.config.ReadFunctions._
 
 private[config] trait ReadFunctions {
   final def read[K, V, A](
     configuration: ConfigDescriptor[K, V, A]
   ): Either[ReadError[K], A] = {
-    def loop[V1, B](
-      configuration: ConfigDescriptor[K, V1, B],
-      keys: Vector[K],
-      paths: Vector[Either[Int, K]]
-    ): (Vector[K], PropertyTree[K, Either[ReadError[K], B]]) =
-      configuration match {
-        case ConfigDescriptor.Source(source: ConfigSource[K, V1], propertyType: PropertyType[V1, B]) =>
-          (
-            keys,
-            source
-              .getConfigValue(keys)
-              .mapEmptyToError(ReadError.MissingValue(paths))
-              .map({
-                case Left(value) => Left(value)
-                case Right(value) =>
-                  propertyType.read(value) match {
-                    case Left(value) =>
-                      Left(
-                        ReadError.FormatError(
-                          paths,
-                          ReadFunctions.parseErrorMessage(value.value.toString, value.typeInfo)
-                        )
-                      )
-                    case Right(value) => Right(value)
-                  }
-              })
-          )
 
-        case s: Sequence[K, V1, B] @unchecked =>
-          val Sequence(config) = s
+    type Res[+B] = Either[ReadError[K], B]
 
-          val (newKey, looped) =
-            loop(config, keys, paths)
+    def formatError(paths: List[Step[K]], actualType: String, expectedType: String) =
+      Left(
+        ReadError.FormatError(paths.reverse, s"Provided value is of type $actualType, expecting the type $expectedType")
+      )
 
-          // A source cannot know if a missing value was a sequence or not, until descriptor says it is.
-          // Hence we transform all those error nodes to a sequence of error nodes to stabilise the tree
-          val sequenceErrors =
-            transformErrors[K, B, ReadError[K]](
-              looped, {
-                case PropertyTree.Leaf(Left(value)) => PropertyTree.Sequence(List(PropertyTree.Leaf(Left(value))))
-              }
-            )
+    def loopDefault[B](path: List[Step[K]], keys: List[K], cfg: Default[K, V, B]): Res[B] =
+      loopAny(path, keys, cfg.config) match {
+        case Left(error) if hasParseErrors(error) || hasConversionErrors(error) => Left(error)
+        case Left(_)                                                            => Right(cfg.value)
+        case Right(value)                                                       => Right(value)
+      }
 
-          (newKey, sequenceErrors.map(_.map(_ :: Nil)).reduceInner[Either[ReadError[K], List[B]]] {
-            case (Right(l), Right(r)) => Right(l ++ r)
-            case (Left(l), Right(_))  => Left(l)
-            case (Right(_), Left(r))  => Left(r)
-            case (Left(l), Left(r))   => Left(ReadError.AndErrors(l :: r :: Nil))
-          })
+    def loopDescribe[B](path: List[Step[K]], keys: List[K], cfg: Describe[K, V, B]): Res[B] =
+      loopAny(path, keys, cfg.config)
 
-        case ConfigDescriptor.Nested(path, c) =>
-          loop(c, keys :+ path, paths :+ Right(path))
+    def loopNested[B](path: List[Step[K]], keys: List[K], cfg: Nested[K, V, B]): Res[B] =
+      loopAny(KeyStep(cfg.path) :: path, cfg.path :: keys, cfg.config)
 
-        case cd: ConfigDescriptor.XmapEither[K, V1, a, B] =>
-          val ConfigDescriptor.XmapEither(c, f, _) = cd
-          val (newKey, looped)                     = loop(c, keys, paths)
+    def loopOptional[B](path: List[Step[K]], keys: List[K], cfg: Optional[K, V, B]): Res[Option[B]] =
+      loopAny(path, keys, cfg.config) match {
+        case Left(error) if hasParseErrors(error) || hasConversionErrors(error) => Left(error)
+        case Left(_)                                                            => Right(None)
+        case Right(value)                                                       => Right(Some(value))
+      }
 
-          (newKey, looped.map {
-            case Left(value) => Left(value)
-            case Right(value) =>
-              f(value) match {
-                case Left(value) => Left(ReadError.ConversionError(newKey.map(Right(_)), value))
-                case Right(value) =>
-                  Right(value)
-              }
-          })
-
-        case cd: ConfigDescriptor.Default[K, V1, B] =>
-          val ConfigDescriptor.Default(config, value) = cd
-
-          val (newKey, looped) = loop(config, keys, paths)
-
-          (newKey, looped.map {
-            case Left(error) if (hasParseErrors(error) || hasConversionErrors(error)) => Left(error)
-            case Left(_)                                                              => Right(value)
-            case Right(value)                                                         => Right(value)
-          })
-
-        case ConfigDescriptor.Describe(c, _) =>
-          loop(c, keys, paths)
-
-        case cd: ConfigDescriptor.Optional[K, V1, B] @unchecked =>
-          val ConfigDescriptor.Optional(c) = cd
-
-          val (newKey, looped) = loop(c, keys, paths)
-
-          (newKey, looped.map {
-            case Left(error) if (hasParseErrors(error) || hasConversionErrors(error)) => Left(error)
-            case Left(_) =>
-              Right(None)
-            case Right(value) =>
-              Right(Some(value))
-          })
-
-        case r: ConfigDescriptor.Zip[K, V1, a, b] @unchecked =>
-          val ConfigDescriptor.Zip(left, right) = r
-
-          val (newKey1, lefts) = loop(left, keys, paths)
-          val (_, rights)      = loop(right, keys, paths)
-
-          (newKey1, (lefts, rights) match {
-            case (l, r) =>
-              l.zipWith(r) { (l, r) =>
-                (l, r) match {
-                  case (Left(l), Left(r))   => Left(AndErrors(List(l, r)))
-                  case (Left(l), Right(_))  => Left(l)
-                  case (Right(_), Left(r))  => Left(r)
-                  case (Right(l), Right(r)) => Right((l, r))
-                }
-              }
-          })
-
-        case cd: ConfigDescriptor.OrElseEither[K, V1, a, b] @unchecked =>
-          val ConfigDescriptor.OrElseEither(left, right) = cd
-
-          val (newKey1, leftTree) =
-            loop(left, keys, paths)
-
-          errors(leftTree) match {
-            case Some(_) =>
-              val (_, rightTree) =
-                loop(right, keys, paths)
-
-              (leftTree, rightTree) match {
-                case (l, r) =>
-                  (newKey1, orElseEither(l, r)((a, b) => OrErrors(List(a, b))))
-              }
-            case None =>
-              (newKey1, leftTree.map({
-                case Left(value)  => Left(value)
-                case Right(value) => Right(Left(value): Either[a, b])
-              }))
-          }
-
-        case ConfigDescriptor.OrElse(left, right) =>
-          val (newKey1, leftTree) =
-            loop(left, keys, paths)
-
-          errors(leftTree) match {
-            case Some(_) =>
-              val (_, rightTree) =
-                loop(right, keys, paths)
-
-              (leftTree, rightTree) match {
-                case (l, r) =>
-                  (newKey1, orElseEither(l, r)((a, b) => OrErrors(List(a, b))).map(_.map(_.merge)))
-              }
-            case None =>
-              (newKey1, leftTree)
+    def loopOrElse[B](path: List[Step[K]], keys: List[K], cfg: OrElse[K, V, B]): Res[B] =
+      loopAny(path, keys, cfg.left) match {
+        case Right(value) => Right(value)
+        case Left(leftError) =>
+          loopAny(path, keys, cfg.right) match {
+            case Right(rightValue) => Right(rightValue)
+            case Left(rightError)  => Left(ReadError.OrErrors(leftError :: rightError :: Nil))
           }
       }
 
-    val (_, tree) =
-      loop(configuration, Vector.empty, Vector.empty)
+    def loopOrElseEither[B, C](path: List[Step[K]], keys: List[K], cfg: OrElseEither[K, V, B, C]): Res[Either[B, C]] =
+      loopAny(path, keys, cfg.left) match {
+        case Right(value) => Right(Left(value))
+        case Left(leftError) =>
+          loopAny(path, keys, cfg.right) match {
+            case Right(rightValue) => Right(Right(rightValue))
+            case Left(rightError)  => Left(ReadError.OrErrors(leftError :: rightError :: Nil))
+          }
+      }
 
-    ReadFunctions.errors(tree) match {
-      case Some(value) =>
-        Left(value)
-      case None =>
-        getValue(tree)
-    }
+    def loopSource[B](path: List[Step[K]], keys: List[K], cfg: Source[K, V, B]): Res[B] =
+      cfg.source.getConfigValue(keys.reverse) match {
+        case PropertyTree.Empty       => Left(ReadError.MissingValue(path.reverse))
+        case PropertyTree.Record(_)   => formatError(path, "Record", "Leaf")
+        case PropertyTree.Sequence(_) => formatError(path, "Sequence", "Leaf")
+        case PropertyTree.Leaf(value) =>
+          cfg.propertyType.read(value) match {
+            case Left(parseError) =>
+              Left(
+                ReadError.FormatError(
+                  path.reverse,
+                  ReadFunctions.parseErrorMessage(parseError.value.toString, parseError.typeInfo)
+                )
+              )
+            case Right(parsed) => Right(parsed)
+          }
+      }
+
+    def loopZip[B, C](path: List[Step[K]], keys: List[K], cfg: Zip[K, V, B, C]): Res[(B, C)] =
+      (loopAny(path, keys, cfg.left), loopAny(path, keys, cfg.right)) match {
+        case (Right(leftV), Right(rightV)) => Right((leftV, rightV))
+        case (Left(leftE), Left(rightE))   => Left(AndErrors(leftE :: rightE :: Nil))
+        case (Left(leftE), _)              => Left(leftE)
+        case (_, Left(rightE))             => Left(rightE)
+      }
+
+    def loopXmapEither[B, C](path: List[Step[K]], keys: List[K], cfg: XmapEither[K, V, B, C]): Res[C] =
+      loopAny(path, keys, cfg.config) match {
+        case Left(error) => Left(error)
+        case Right(a)    => cfg.f(a).swap.map(ReadError.ConversionError(path.reverse, _)).swap
+      }
+
+    def loopSequence[B](path: List[Step[K]], keys: List[K], cfg: Sequence[K, V, B]): Res[List[B]] =
+      cfg.source.getConfigValue(keys.reverse) match {
+        case PropertyTree.Leaf(_)   => formatError(path, "Leaf", "Sequence")
+        case PropertyTree.Record(_) => formatError(path, "Record", "Sequence")
+        case PropertyTree.Empty     => Left(ReadError.MissingValue(path.reverse))
+        case PropertyTree.Sequence(values) =>
+          val list = values.zipWithIndex.map {
+            case (tree, idx) =>
+              val source = ConfigSource(tree, cfg.source.sourceDescription)
+              loopAny(IndexStep(idx) :: path, Nil, cfg.config.updateSource(_ => source))
+          }
+          seqEither2[ReadError[K], B, ReadError[K]]((_, a) => a)(list).swap.map(AndErrors(_)).swap
+      }
+
+    def loopAny[B](path: List[Step[K]], keys: List[K], config: ConfigDescriptor[K, V, B]): Res[B] =
+      config match {
+        case c @ Default(_, _)       => loopDefault(path, keys, c)
+        case c @ Describe(_, _)      => loopDescribe(path, keys, c)
+        case c @ Nested(_, _)        => loopNested(path, keys, c)
+        case c @ Optional(_)         => loopOptional(path, keys, c)
+        case c @ OrElse(_, _)        => loopOrElse(path, keys, c)
+        case c @ OrElseEither(_, _)  => loopOrElseEither(path, keys, c)
+        case c @ Source(_, _)        => loopSource(path, keys, c)
+        case c @ Zip(_, _)           => loopZip(path, keys, c)
+        case c @ XmapEither(_, _, _) => loopXmapEither(path, keys, c)
+        case c @ Sequence(_, _)      => loopSequence(path, keys, c)
+      }
+
+    loopAny(Nil, Nil, configuration)
   }
 }
 
 object ReadFunctions {
 
-  def orElseEither[K, E1, E2, E3, A, B](
-    tree1: PropertyTree[K, Either[E1, A]],
-    tree2: PropertyTree[K, Either[E2, B]]
-  )(f: (E1, E2) => E3): PropertyTree[K, Either[E3, Either[A, B]]] =
-    tree1.zipWith(tree2)(
-      (a, b) =>
-        a match {
-          case Left(error1) =>
-            b match {
-              case Left(error2) => Left(f(error1, error2))
-              case Right(value) => Right(Right(value))
-            }
-          case Right(value) => Right(Left(value))
-        }
-    )
-
-  final def transformErrors[K1, V1, E](
-    propertyTree: PropertyTree[K1, Either[E, V1]],
-    f: PartialFunction[PropertyTree[K1, Either[E, V1]], PropertyTree[K1, Either[E, V1]]]
-  ): PropertyTree[K1, Either[E, V1]] =
-    propertyTree match {
-      case x @ PropertyTree.Leaf(_) => f.lift(x).getOrElse(x)
-      case _ @PropertyTree.Record(value) =>
-        val r: PropertyTree[K1, Either[E, V1]] = PropertyTree.Record(
-          value.mapValues(tree => transformErrors(tree, f)).toMap[K1, PropertyTree[K1, Either[E, V1]]]
-        )
-        f.lift(r).getOrElse(r)
-      case _ @PropertyTree.Sequence(value) =>
-        val s = PropertyTree.Sequence(value.map(tree => transformErrors(tree, f)))
-        f.lift(s).getOrElse(s)
-      case x if x == PropertyTree.Empty => f.lift(x).getOrElse(x)
-
-    }
-
-  def getValue[K, V](propertyTree: PropertyTree[K, Either[ReadError[K], V]]): Either[ReadError[K], V] =
-    propertyTree match {
-      case PropertyTree.Leaf(value) =>
-        value match {
-          case Left(value)  => Left(value)
-          case Right(value) => Right(value)
-        }
-      case PropertyTree.Record(value) => getValue(value.toList.map(_._2).head)
-      case PropertyTree.Empty | PropertyTree.Sequence(Nil) =>
-        Left(ReadError.ConversionError(Vector.empty, "Unable to form the configuration."))
-      case PropertyTree.Sequence(value) => getValue(value.head)
-    }
-
   def parseErrorMessage(given: String, expectedType: String) =
     s"Provided value is ${given.toString}, expecting the type ${expectedType}"
 
-  final def hasErrors[K](value: ReadError[K])(f: PartialFunction[ReadError[K], Boolean]): Boolean =
+  private def hasErrors[K](value: ReadError[K])(f: PartialFunction[ReadError[K], Boolean]): Boolean =
     f.orElse[ReadError[K], Boolean]({
         case OrErrors(errors)  => errors.exists(hasErrors(_)(f))
         case AndErrors(errors) => errors.exists(hasErrors(_)(f))
@@ -232,46 +133,9 @@ object ReadFunctions {
       .lift(value)
       .getOrElse(false)
 
-  final def hasParseErrors[K](error: ReadError[K]): Boolean =
+  private def hasParseErrors[K](error: ReadError[K]): Boolean =
     hasErrors(error)({ case ReadError.FormatError(_, _) => true })
 
-  final def hasConversionErrors[K](error: ReadError[K]): Boolean =
+  private def hasConversionErrors[K](error: ReadError[K]): Boolean =
     hasErrors(error)({ case ReadError.ConversionError(_, _) => true })
-
-  final def errors[K, V1, B](tree: PropertyTree[K, Either[ReadError[K], B]]): Option[ReadError[K]] = {
-    def loop(tree: PropertyTree[K, Either[ReadError[K], B]], acc: Option[ReadError[K]]): Option[ReadError[K]] =
-      tree match {
-        case PropertyTree.Leaf(value) =>
-          value match {
-            case Left(value) =>
-              Some(acc.fold(value)({
-                case AndErrors(list) => AndErrors(value :: list)
-                case errors          => AndErrors(List(errors, value))
-              }))
-            case Right(_) => acc
-          }
-        case PropertyTree.Record(value) =>
-          value.toList.map(_._2).map(tree => loop(tree, acc)).foldLeft(None: Option[ReadError[K]]) { (acc, a) =>
-            (acc, a) match {
-              case (Some(l), Some(r)) => Some(AndErrors(List(l, r)))
-              case (_, Some(value))   => Some(value)
-              case (Some(value), _)   => Some(value)
-              case (None, None)       => None
-            }
-          }
-        case PropertyTree.Sequence(value) =>
-          value.map(tree => loop(tree, acc)).foldLeft(None: Option[ReadError[K]]) { (acc, a) =>
-            (acc, a) match {
-              case (Some(l), Some(r)) => Some(AndErrors(List(l, r)))
-              case (_, Some(value))   => Some(value)
-              case (Some(value), _)   => Some(value)
-              case (None, None)       => None
-            }
-          }
-
-        case PropertyTree.Empty => None
-      }
-
-    loop(tree, None)
-  }
 }

--- a/core/src/main/scala/zio/config/ReadFunctions.scala
+++ b/core/src/main/scala/zio/config/ReadFunctions.scala
@@ -1,7 +1,7 @@
 package zio.config
 
 import zio.config.ConfigDescriptor._
-import zio.config.ReadError.{ AndErrors, IndexStep, KeyStep, OrErrors, Step }
+import zio.config.ReadError.{ AndErrors, OrErrors, Step }
 import zio.config.ReadFunctions._
 
 private[config] trait ReadFunctions {
@@ -27,7 +27,7 @@ private[config] trait ReadFunctions {
       loopAny(path, keys, cfg.config)
 
     def loopNested[B](path: List[Step[K]], keys: List[K], cfg: Nested[K, V, B]): Res[B] =
-      loopAny(KeyStep(cfg.path) :: path, cfg.path :: keys, cfg.config)
+      loopAny(Step.Key(cfg.path) :: path, cfg.path :: keys, cfg.config)
 
     def loopOptional[B](path: List[Step[K]], keys: List[K], cfg: Optional[K, V, B]): Res[Option[B]] =
       loopAny(path, keys, cfg.config) match {
@@ -97,7 +97,7 @@ private[config] trait ReadFunctions {
           val list = values.zipWithIndex.map {
             case (tree, idx) =>
               val source = ConfigSource(tree, cfg.source.sourceDescription)
-              loopAny(IndexStep(idx) :: path, Nil, cfg.config.updateSource(_ => source))
+              loopAny(Step.Index(idx) :: path, Nil, cfg.config.updateSource(_ => source))
           }
           seqEither2[ReadError[K], B, ReadError[K]]((_, a) => a)(list).swap.map(AndErrors(_)).swap
       }

--- a/core/src/test/scala/zio/config/ArgsListAccumulationTest.scala
+++ b/core/src/test/scala/zio/config/ArgsListAccumulationTest.scala
@@ -27,7 +27,7 @@ object ArgsListAccumulationTest extends DefaultRunnableSpec {
 
   object SomeConfig {
     val descriptor: ConfigDescriptor[String, String, SomeConfig] =
-      list(int("ints"))(SomeConfig.apply, SomeConfig.unapply)
+      list("ints")(int)(SomeConfig.apply, SomeConfig.unapply)
   }
 
   def renderArgs(count: Int): List[String] =

--- a/core/src/test/scala/zio/config/CommandLineListAccumulationTest.scala
+++ b/core/src/test/scala/zio/config/CommandLineListAccumulationTest.scala
@@ -27,7 +27,7 @@ object ListAccumulationTest extends DefaultRunnableSpec {
 
   object SomeConfig {
     val descriptor: ConfigDescriptor[String, String, SomeConfig] =
-      list(int("ints"))(SomeConfig.apply, SomeConfig.unapply)
+      list("ints")(int)(SomeConfig.apply, SomeConfig.unapply)
   }
 
   def renderArgs(count: Int): List[String] =

--- a/core/src/test/scala/zio/config/CommandLineSourceTest.scala
+++ b/core/src/test/scala/zio/config/CommandLineSourceTest.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.config.ReadError.{ ConversionError, IndexStep }
+import zio.config.ReadError.{ ConversionError, Step }
 import zio.config.testsupport.MapConfigTestSupport.AppConfig.descriptor
 import zio.config.testsupport.MapConfigTestSupport.{ genAppConfig, AppConfig }
 import zio.test.Assertion._
@@ -55,7 +55,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](List(IndexStep(0)), s),
+        s => ConversionError[String](List(Step.Index(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"--${t._1.mkString("_")}", t._2.mkString)
@@ -65,7 +65,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   def toSingleArg[A](descriptor: ConfigDescriptor[String, String, A], a: A): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](List(IndexStep(0)), s),
+        s => ConversionError[String](List(Step.Index(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"-${t._1.mkString("_")}=${t._2.mkString}")
@@ -78,7 +78,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](List(IndexStep(0)), s),
+        s => ConversionError[String](List(Step.Index(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"--${t._1.mkString("_")}=${t._2.mkString}") ++

--- a/core/src/test/scala/zio/config/CommandLineSourceTest.scala
+++ b/core/src/test/scala/zio/config/CommandLineSourceTest.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.config.ReadError.ConversionError
+import zio.config.ReadError.{ ConversionError, IndexStep }
 import zio.config.testsupport.MapConfigTestSupport.AppConfig.descriptor
 import zio.config.testsupport.MapConfigTestSupport.{ genAppConfig, AppConfig }
 import zio.test.Assertion._
@@ -55,7 +55,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](Vector(Left(0)), s),
+        s => ConversionError[String](List(IndexStep(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"--${t._1.mkString("_")}", t._2.mkString)
@@ -65,7 +65,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   def toSingleArg[A](descriptor: ConfigDescriptor[String, String, A], a: A): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](Vector(Left(0)), s),
+        s => ConversionError[String](List(IndexStep(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"-${t._1.mkString("_")}=${t._2.mkString}")
@@ -78,7 +78,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], List[String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](Vector(Left(0)), s),
+        s => ConversionError[String](List(IndexStep(0)), s),
         propertyTree =>
           propertyTree.flatten.toList.flatMap { t: (Vector[String], ::[String]) =>
             List(s"--${t._1.mkString("_")}=${t._2.mkString}") ++

--- a/core/src/test/scala/zio/config/CoproductTest.scala
+++ b/core/src/test/scala/zio/config/CoproductTest.scala
@@ -29,8 +29,8 @@ object CoproductTest
             val expected: ReadError[String] =
               OrErrors(
                 List(
-                  MissingValue(Vector(Right(p.kLdap))),
-                  FormatError(Vector(Right(p.kFactor)), ReadFunctions.parseErrorMessage("notafloat", "float"))
+                  MissingValue(List(KeyStep(p.kLdap))),
+                  FormatError(List(KeyStep(p.kFactor)), ReadFunctions.parseErrorMessage("notafloat", "float"))
                 )
               )
             assert(readWithErrors(p))(isLeft(equalTo(expected)))

--- a/core/src/test/scala/zio/config/CoproductTest.scala
+++ b/core/src/test/scala/zio/config/CoproductTest.scala
@@ -29,8 +29,8 @@ object CoproductTest
             val expected: ReadError[String] =
               OrErrors(
                 List(
-                  MissingValue(List(KeyStep(p.kLdap))),
-                  FormatError(List(KeyStep(p.kFactor)), ReadFunctions.parseErrorMessage("notafloat", "float"))
+                  MissingValue(List(Step.Key(p.kLdap))),
+                  FormatError(List(Step.Key(p.kFactor)), ReadFunctions.parseErrorMessage("notafloat", "float"))
                 )
               )
             assert(readWithErrors(p))(isLeft(equalTo(expected)))

--- a/core/src/test/scala/zio/config/GenerateDocsTest.scala
+++ b/core/src/test/scala/zio/config/GenerateDocsTest.scala
@@ -75,7 +75,7 @@ object GenerateDocsTestUtils {
           NestedPath(
             keys.secret,
             Leaf(
-              Sources(List("test")),
+              Sources(Set("test")),
               List("value of type string", "optional value", "Application secret")
             )
           ),
@@ -85,14 +85,14 @@ object GenerateDocsTestUtils {
               NestedPath(
                 keys.user,
                 Leaf(
-                  Sources(List("test")),
+                  Sources(Set("test")),
                   List("value of type string", "Example: ZioUser", "Credentials")
                 )
               ),
               NestedPath(
                 keys.password,
                 Leaf(
-                  Sources(List("test")),
+                  Sources(Set("test")),
                   List("value of type string", "Example: ZioPass", "Credentials")
                 )
               )
@@ -105,14 +105,14 @@ object GenerateDocsTestUtils {
             NestedPath(
               keys.port,
               Leaf(
-                Sources(List("test")),
+                Sources(Set("test")),
                 List("value of type int", "Example: 8088", "Database")
               )
             ),
             NestedPath(
               keys.url,
               Leaf(
-                Sources(List("test")),
+                Sources(Set("test")),
                 List("value of type string", "Example: abc.com", "Database")
               )
             )
@@ -127,7 +127,7 @@ object GenerateDocsTestUtils {
             NestedPath(
               keys.secret,
               Leaf(
-                Sources(List("test")),
+                Sources(Set("test")),
                 List("value of type string", "optional value", "Application secret"),
                 value.secret
               )
@@ -138,7 +138,7 @@ object GenerateDocsTestUtils {
                 NestedPath(
                   keys.user,
                   Leaf(
-                    Sources(List("test")),
+                    Sources(Set("test")),
                     List("value of type string", "Example: ZioUser", "Credentials"),
                     Some(value.credentials.user)
                   )
@@ -146,7 +146,7 @@ object GenerateDocsTestUtils {
                 NestedPath(
                   keys.password,
                   Leaf(
-                    Sources(List("test")),
+                    Sources(Set("test")),
                     List("value of type string", "Example: ZioPass", "Credentials"),
                     Some(value.credentials.password)
                   )
@@ -160,7 +160,7 @@ object GenerateDocsTestUtils {
               NestedPath(
                 keys.port,
                 Leaf(
-                  Sources(List("test")),
+                  Sources(Set("test")),
                   List("value of type int", "Example: 8088", "Database"),
                   Some(value.database.port).map(_.toString)
                 )
@@ -168,7 +168,7 @@ object GenerateDocsTestUtils {
               NestedPath(
                 keys.url,
                 Leaf(
-                  Sources(List("test")),
+                  Sources(Set("test")),
                   List("value of type string", "Example: abc.com", "Database"),
                   Some(value.database.url)
                 )

--- a/core/src/test/scala/zio/config/ListAndOptionalTest.scala
+++ b/core/src/test/scala/zio/config/ListAndOptionalTest.scala
@@ -3,22 +3,109 @@ package zio.config
 import zio.ZIO
 import zio.config.ConfigDescriptor._
 import zio.config.ListAndOptionalTestUtils._
+import zio.config.PropertyTree.{ Leaf, Record }
 import zio.config.helpers._
 import zio.test.Assertion._
 import zio.test._
 
 object ListAndOptionalTest
-    extends BaseSpec(suite("List and options")(testM("optional write") {
-      checkM(genOverallConfig) { p =>
-        val actual = ZIO.fromEither(write(cOverallConfig, p)).map(_.flattenString())
+    extends BaseSpec(
+      suite("List and options")(
+        testM("optional write") {
+          checkM(genOverallConfig) { p =>
+            val actual = ZIO.fromEither(write(cOverallConfig, p)).map(_.flattenString())
 
-        val expected = p.option
-          .flatMap(t => t.flatMap(tt => tt.map(ttt => Map("kId" -> singleton(ttt.value)))))
-          .getOrElse(Map.empty[String, ::[String]])
+            val expected = p.option
+              .flatMap(t => t.flatMap(tt => tt.map(ttt => Map("kId" -> singleton(ttt.value)))))
+              .getOrElse(Map.empty[String, ::[String]])
 
-        assertM(actual)(equalTo(expected))
-      }
-    }))
+            assertM(actual)(equalTo(expected))
+          }
+        },
+        testM("list read") {
+
+          val src =
+            ConfigSource.fromPropertyTree(
+              Record(
+                Map(
+                  "list" -> PropertyTree.Sequence(
+                    List(
+                      Record(
+                        Map(
+                          "a" -> Leaf("1"),
+                          "b" -> Leaf("1"),
+                          "c" -> Leaf("1")
+                        )
+                      ),
+                      Record(
+                        Map(
+                          "a" -> Leaf("2"),
+                          "b" -> Leaf("2")
+                        )
+                      ),
+                      Record(
+                        Map(
+                          "a" -> Leaf("3")
+                        )
+                      ),
+                      Record(
+                        Map(
+                          "a" -> Leaf("4"),
+                          "c" -> Leaf("4")
+                        )
+                      ),
+                      Record(
+                        Map(
+                          "a" -> Leaf("5"),
+                          "b" -> Leaf("5"),
+                          "c" -> Leaf("5")
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              "src"
+            )
+
+          val actual = ZIO.fromEither(read(cListConfig from src))
+
+          val expectet = ListConfig(
+            List(
+              Opt3Config(Id("1"), Some(Id("1")), Some(Id("1"))),
+              Opt3Config(Id("2"), Some(Id("2")), None),
+              Opt3Config(Id("3"), None, None),
+              Opt3Config(Id("4"), None, Some(Id("4"))),
+              Opt3Config(Id("5"), Some(Id("5")), Some(Id("5")))
+            )
+          )
+
+          assertM(actual)(equalTo(expectet))
+        },
+        testM("empty list read") {
+
+          val src =
+            ConfigSource.fromPropertyTree(
+              Record(Map("list" -> PropertyTree.Sequence[String, String](Nil))),
+              "src"
+            )
+
+          val actual = ZIO.fromEither(read(cListConfig from src))
+
+          val expected = ListConfig(Nil)
+
+          assertM(actual)(equalTo(expected))
+        },
+        testM("list write read") {
+          checkM(genListConfig) { p =>
+            val actual = ZIO.fromEither(write(cListConfig, p).flatMap { tree =>
+              read(cListConfig from ConfigSource.fromPropertyTree(tree, "tree"))
+            })
+            assertM(actual)(equalTo(p))
+          }
+        }
+      )
+    )
 
 object ListAndOptionalTestUtils {
   final case class OverallConfig(option: Option[Option[Option[Id]]])
@@ -26,8 +113,25 @@ object ListAndOptionalTestUtils {
   val genOverallConfig =
     Gen.option(genId).map(t => OverallConfig(t.map(t => Option(Option(t)))))
 
-  private val cId = string("kId")(Id.apply, Id.unapply)
+  private def id(path: String) = string(path)(Id.apply, Id.unapply)
+
+  private val cId = id("kId")
 
   val cOverallConfig =
     cId.optional.optional.optional(OverallConfig.apply, OverallConfig.unapply)
+
+  final case class Opt3Config(a: Id, b: Option[Id], c: Option[Id])
+  final case class ListConfig(list: List[Opt3Config])
+
+  val cOpt3Config = (id("a") |@| id("b").optional |@| id("c").optional)(Opt3Config, Opt3Config.unapply)
+
+  val cListConfig = list("list")(cOpt3Config)(ListConfig, ListConfig.unapply)
+
+  val genOpt3Config = for {
+    a <- genId
+    b <- Gen.option(genId)
+    c <- Gen.option(genId)
+  } yield Opt3Config(a, b, c)
+
+  val genListConfig = Gen.listOf(genOpt3Config).map(ListConfig)
 }

--- a/core/src/test/scala/zio/config/ListsCornerCasesTest.scala
+++ b/core/src/test/scala/zio/config/ListsCornerCasesTest.scala
@@ -13,7 +13,7 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| list("b")(string))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Nil))))
         },
@@ -23,7 +23,9 @@ object ListsCornerCasesTest
           val cCfg = (string("a") |@| list("b")(list(string)))(Cfg, Cfg.unapply)
 
           val res =
-            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Sequence(Nil) :: Nil))), Nil))
+            read(
+              cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Sequence(Nil) :: Nil))), Set.empty)
+            )
 
           assert(res)(isRight(equalTo(Cfg("sa", Nil :: Nil))))
         },
@@ -33,7 +35,7 @@ object ListsCornerCasesTest
           val cCfg = (string("a") |@| list("b")(string).optional)(Cfg, Cfg.unapply)
 
           val res =
-            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Nil))
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", None))))
         },
@@ -43,7 +45,7 @@ object ListsCornerCasesTest
           val cCfg = (string("a") |@| list("b")(string).optional)(Cfg, Cfg.unapply)
 
           val res =
-            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Some(Nil)))))
         },
@@ -52,7 +54,7 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| list("b")(string).default("x" :: Nil))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", "x" :: Nil))))
         },
@@ -61,7 +63,7 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| list("b")(string).default("x" :: Nil))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Nil))))
         },
@@ -70,7 +72,8 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| nested("b")(listStrict(string).orElseEither(string)))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Nil))
+          val res =
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Left("v" :: Nil)))))
         },
@@ -79,7 +82,8 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| nested("b")(string.orElseEither(listStrict(string))))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Nil))
+          val res =
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Right("v" :: Nil)))))
         },
@@ -88,7 +92,7 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| nested("b")(string.orElseEither(listStrict(string))))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Left("v")))))
         },
@@ -97,7 +101,7 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| nested("b")(listStrict(string).orElseEither(string)))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", Right("v")))))
         },
@@ -106,19 +110,19 @@ object ListsCornerCasesTest
 
           val cCfg = (string("a") |@| list("b")(string))(Cfg, Cfg.unapply)
 
-          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Set.empty))
 
           assert(res)(isRight(equalTo(Cfg("sa", "v" :: Nil))))
         },
         test("read list as scalar") {
           case class Cfg(a: String, b: String)
 
-          val cCfg = (string("a") |@| first("b")(string))(Cfg, Cfg.unapply)
+          val cCfg = (string("a") |@| head("b")(string))(Cfg, Cfg.unapply)
 
           val res = read(
             cCfg from ConfigSource(
               Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v1") :: Leaf("v2") :: Nil))),
-              Nil
+              Set.empty
             )
           )
 
@@ -142,7 +146,7 @@ object ListsCornerCasesTest
                   )
                 )
               ),
-              Nil
+              Set.empty
             )
           )
 
@@ -158,7 +162,7 @@ object ListsCornerCasesTest
               Record(
                 Map("a" -> Leaf("sa"), "b" -> Sequence(Record[String, String](Map.empty) :: Sequence(Nil) :: Nil))
               ),
-              Nil
+              Set.empty
             )
           )
 

--- a/core/src/test/scala/zio/config/ListsCornerCasesTest.scala
+++ b/core/src/test/scala/zio/config/ListsCornerCasesTest.scala
@@ -1,0 +1,168 @@
+package zio.config
+
+import zio.config.ConfigDescriptor.{ Source => _, _ }
+import zio.config.PropertyTree.{ Leaf, Record, Sequence }
+import zio.test.Assertion._
+import zio.test._
+
+object ListsCornerCasesTest
+    extends BaseSpec(
+      suite("ListsCornerCasesTest")(
+        test("read empty list") {
+          case class Cfg(a: String, b: List[String])
+
+          val cCfg = (string("a") |@| list("b")(string))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Nil))))
+        },
+        test("read nested lists") {
+          case class Cfg(a: String, b: List[List[String]])
+
+          val cCfg = (string("a") |@| list("b")(list(string)))(Cfg, Cfg.unapply)
+
+          val res =
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Sequence(Nil) :: Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Nil :: Nil))))
+        },
+        test("read absent optional lists") {
+          case class Cfg(a: String, b: Option[List[String]])
+
+          val cCfg = (string("a") |@| list("b")(string).optional)(Cfg, Cfg.unapply)
+
+          val res =
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", None))))
+        },
+        test("read present optional empty lists") {
+          case class Cfg(a: String, b: Option[List[String]])
+
+          val cCfg = (string("a") |@| list("b")(string).optional)(Cfg, Cfg.unapply)
+
+          val res =
+            read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Some(Nil)))))
+        },
+        test("use default value for absent list") {
+          case class Cfg(a: String, b: List[String])
+
+          val cCfg = (string("a") |@| list("b")(string).default("x" :: Nil))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", "x" :: Nil))))
+        },
+        test("override default non-empty list with empty list") {
+          case class Cfg(a: String, b: List[String])
+
+          val cCfg = (string("a") |@| list("b")(string).default("x" :: Nil))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Nil))))
+        },
+        test("distinguish list from scalar left") {
+          case class Cfg(a: String, b: Either[List[String], String])
+
+          val cCfg = (string("a") |@| nested("b")(listStrict(string).orElseEither(string)))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Left("v" :: Nil)))))
+        },
+        test("distinguish list from scalar right") {
+          case class Cfg(a: String, b: Either[String, List[String]])
+
+          val cCfg = (string("a") |@| nested("b")(string.orElseEither(listStrict(string))))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v") :: Nil))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Right("v" :: Nil)))))
+        },
+        test("distinguish scalar from list left") {
+          case class Cfg(a: String, b: Either[String, List[String]])
+
+          val cCfg = (string("a") |@| nested("b")(string.orElseEither(listStrict(string))))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Left("v")))))
+        },
+        test("distinguish scalar from list right") {
+          case class Cfg(a: String, b: Either[List[String], String])
+
+          val cCfg = (string("a") |@| nested("b")(listStrict(string).orElseEither(string)))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", Right("v")))))
+        },
+        test("read scalar as list") {
+          case class Cfg(a: String, b: List[String])
+
+          val cCfg = (string("a") |@| list("b")(string))(Cfg, Cfg.unapply)
+
+          val res = read(cCfg from ConfigSource(Record(Map("a" -> Leaf("sa"), "b" -> Leaf("v"))), Nil))
+
+          assert(res)(isRight(equalTo(Cfg("sa", "v" :: Nil))))
+        },
+        test("read list as scalar") {
+          case class Cfg(a: String, b: String)
+
+          val cCfg = (string("a") |@| first("b")(string))(Cfg, Cfg.unapply)
+
+          val res = read(
+            cCfg from ConfigSource(
+              Record(Map("a" -> Leaf("sa"), "b" -> Sequence(Leaf("v1") :: Leaf("v2") :: Nil))),
+              Nil
+            )
+          )
+
+          assert(res)(isRight(equalTo(Cfg("sa", "v1"))))
+        },
+        test("read single key objects in nested lists") {
+          case class Cfg(a: String, b: List[List[String]])
+
+          val cCfg = (string("a") |@| list("b")(listStrict(string("c"))))(Cfg, Cfg.unapply)
+
+          val res = read(
+            cCfg from ConfigSource(
+              Record(
+                Map(
+                  "a" -> Leaf("sa"),
+                  "b" -> Sequence[String, String](
+                    Sequence(Record(Map("c" -> Leaf("v1"))) :: Nil) ::
+                      Sequence(Nil) ::
+                      Sequence(Record(Map("c" -> Leaf("v2"))) :: Record(Map("c" -> Leaf("v3"))) :: Nil) ::
+                      Nil
+                  )
+                )
+              ),
+              Nil
+            )
+          )
+
+          assert(res)(isRight(equalTo(Cfg("sa", List("v1") :: Nil :: List("v2", "v3") :: Nil))))
+        },
+        test("collect errors from list elements") {
+          case class Cfg(a: String, b: List[String])
+
+          val cCfg = (string("a") |@| nested("b")(listStrict(string)))(Cfg, Cfg.unapply)
+
+          val res = read(
+            cCfg from ConfigSource(
+              Record(
+                Map("a" -> Leaf("sa"), "b" -> Sequence(Record[String, String](Map.empty) :: Sequence(Nil) :: Nil))
+              ),
+              Nil
+            )
+          )
+
+          assert(res)(isLeft(hasField("size", _.size, equalTo(2))))
+        }
+      )
+    )

--- a/core/src/test/scala/zio/config/MapConfigTest.scala
+++ b/core/src/test/scala/zio/config/MapConfigTest.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.config.ReadError.{ ConversionError, IndexStep }
+import zio.config.ReadError.{ ConversionError, Step }
 import zio.config.testsupport.MapConfigTestSupport.AppConfig.descriptor
 import zio.test.Assertion._
 import zio.test._
@@ -34,7 +34,7 @@ object MapConfigTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], Map[String, String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](List(IndexStep(0)), s),
+        s => ConversionError[String](List(Step.Index(0)), s),
         propertyTreeArgs
       )
       .map(tuples => Map(tuples: _*))

--- a/core/src/test/scala/zio/config/MapConfigTest.scala
+++ b/core/src/test/scala/zio/config/MapConfigTest.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.config.ReadError.ConversionError
+import zio.config.ReadError.{ ConversionError, IndexStep }
 import zio.config.testsupport.MapConfigTestSupport.AppConfig.descriptor
 import zio.test.Assertion._
 import zio.test._
@@ -34,7 +34,7 @@ object MapConfigTest extends DefaultRunnableSpec {
   ): ZIO[Any, ReadError[String], Map[String, String]] =
     IO.fromEither(write(descriptor, a))
       .bimap(
-        s => ConversionError[String](Vector(Left(0)), s),
+        s => ConversionError[String](List(IndexStep(0)), s),
         propertyTreeArgs
       )
       .map(tuples => Map(tuples: _*))

--- a/core/src/test/scala/zio/config/ReadErrorsTest.scala
+++ b/core/src/test/scala/zio/config/ReadErrorsTest.scala
@@ -1,9 +1,10 @@
 package zio.config
 
-import ReadErrorsTestUtils._
+import zio.config.ReadError.KeyStep
+import zio.config.ReadErrorsTestUtils._
 import zio.random.Random
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object ReadErrorsTest
     extends BaseSpec(
@@ -24,10 +25,10 @@ object ReadErrorsTestUtils {
       s1 <- Gen.anyString
       s2 <- Gen.anyString
       s3 <- Gen.anyString
-    } yield ReadError.FormatError(Vector(Right(s1)), ReadFunctions.parseErrorMessage(s2, s3))
+    } yield ReadError.FormatError(List(KeyStep(s1)), ReadFunctions.parseErrorMessage(s2, s3))
 
   private val genReadError =
-    Gen.oneOf(Gen.const(ReadError.MissingValue(Vector(Right("somekey")))), genFormatError)
+    Gen.oneOf(Gen.const(ReadError.MissingValue(List(KeyStep("somekey")))), genFormatError)
 
   val genReadErrors: Gen[Random with Sized, List[ReadError[String]]] = {
     for {

--- a/core/src/test/scala/zio/config/ReadErrorsTest.scala
+++ b/core/src/test/scala/zio/config/ReadErrorsTest.scala
@@ -1,6 +1,6 @@
 package zio.config
 
-import zio.config.ReadError.KeyStep
+import zio.config.ReadError.Step
 import zio.config.ReadErrorsTestUtils._
 import zio.random.Random
 import zio.test.Assertion._
@@ -25,10 +25,10 @@ object ReadErrorsTestUtils {
       s1 <- Gen.anyString
       s2 <- Gen.anyString
       s3 <- Gen.anyString
-    } yield ReadError.FormatError(List(KeyStep(s1)), ReadFunctions.parseErrorMessage(s2, s3))
+    } yield ReadError.FormatError(List(Step.Key(s1)), ReadFunctions.parseErrorMessage(s2, s3))
 
   private val genReadError =
-    Gen.oneOf(Gen.const(ReadError.MissingValue(List(KeyStep("somekey")))), genFormatError)
+    Gen.oneOf(Gen.const(ReadError.MissingValue(List(Step.Key("somekey")))), genFormatError)
 
   val genReadErrors: Gen[Random with Sized, List[ReadError[String]]] = {
     for {

--- a/core/src/test/scala/zio/config/helpers.scala
+++ b/core/src/test/scala/zio/config/helpers.scala
@@ -27,6 +27,12 @@ object helpers {
 
   val genDbUrl: Gen[Random, DbUrl] = genNonEmptyString(20).map(DbUrl)
 
+  def isErrors[A](assertion: Assertion[ReadError[String]]): Assertion[Either[ReadError[String], A]] =
+    Assertion.assertionRec("isErrors")(Assertion.Render.param(assertion))(assertion) {
+      case Left(errs: ReadError[String]) => Some(errs)
+      case Right(_)                      => None
+    }
+
   def assertErrors[A](
     pred: ReadError[String] => Boolean
   ): Assertion[Either[ReadError[String], A]] =

--- a/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
+++ b/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
@@ -1,7 +1,7 @@
 package zio.config.testsupport
 
 import zio.config.ConfigDescriptor
-import zio.config.ConfigDescriptor.{ boolean, first, string }
+import zio.config.ConfigDescriptor.{ boolean, head, string }
 import zio.random.Random
 import zio.test.Gen.alphaNumericChar
 import zio.test.{ Gen, Sized }
@@ -40,8 +40,8 @@ object MapConfigTestSupport {
 
     object AwsConfig {
       val description: ConfigDescriptor[String, String, AwsConfig] =
-        first("aws")(
-          (first("key")(string) |@| first("secret")(string) |@| KinesisConfig.description)(
+        head("aws")(
+          (head("key")(string) |@| head("secret")(string) |@| KinesisConfig.description)(
             AwsConfig.apply,
             AwsConfig.unapply
           )
@@ -52,18 +52,18 @@ object MapConfigTestSupport {
 
     object KinesisConfig {
       val description =
-        (first("kinesis")(first("inputtopic")(string))(KinesisConfig.apply, KinesisConfig.unapply))
+        (head("kinesis")(head("inputtopic")(string))(KinesisConfig.apply, KinesisConfig.unapply))
     }
 
     final case class PubSubConfig(outputTopic: String)
 
     object PubSubConfig {
       val description =
-        first("ps")(first("outputtopic")(string)(PubSubConfig.apply, PubSubConfig.unapply))
+        head("ps")(head("outputtopic")(string)(PubSubConfig.apply, PubSubConfig.unapply))
     }
 
     val descriptor: ConfigDescriptor[String, String, AppConfig] =
-      first("SystemF")(
+      head("SystemF")(
         (AwsConfig.description |@| AppConfig.PubSubConfig.description |@| JobConfig.descriptor)(
           AppConfig.apply,
           AppConfig.unapply
@@ -82,13 +82,13 @@ object MapConfigTestSupport {
 
   object DataflowConfig {
     val descriptor: ConfigDescriptor[String, String, DataflowConfig] =
-      first("df")(
-        ((first("name")(string)) |@|
-          first("project")(string) |@|
-          first("region")(string) |@|
-          first("zone")(string) |@|
-          first("subnet")(string) |@|
-          first("gcptemplocation")(string))(DataflowConfig.apply, DataflowConfig.unapply)
+      head("df")(
+        ((head("name")(string)) |@|
+          head("project")(string) |@|
+          head("region")(string) |@|
+          head("zone")(string) |@|
+          head("subnet")(string) |@|
+          head("gcptemplocation")(string))(DataflowConfig.apply, DataflowConfig.unapply)
       )
   }
 
@@ -101,8 +101,8 @@ object MapConfigTestSupport {
 
   object JobConfig {
     val descriptor: ConfigDescriptor[String, String, JobConfig] =
-      first("job")(
-        (DataflowConfig.descriptor.optional |@| first("supervise")(boolean))(JobConfig.apply, JobConfig.unapply)
+      head("job")(
+        (DataflowConfig.descriptor.optional |@| head("supervise")(boolean))(JobConfig.apply, JobConfig.unapply)
       )
   }
 

--- a/docs/configdescriptor/index.md
+++ b/docs/configdescriptor/index.md
@@ -378,7 +378,7 @@ NOTE: `collectAll` is a synonym for `sequence`.
   final case class PgmConfig(a: String, b: List[String])
   
   val configWithList = 
-    (string("xyz") |@| list(string("regions")))(PgmConfig.apply, PgmConfig.unapply)
+    (string("xyz") |@| list("regions")(string))(PgmConfig.apply, PgmConfig.unapply)
 
   
   Config.fromEnv(configWithList, valueDelimiter = Some(","))

--- a/docs/refined/index.md
+++ b/docs/refined/index.md
@@ -29,7 +29,7 @@ object RefinedReadConfig extends App {
       nonEmpty(string("LDAP")) |@|
         greaterEqual[W.`1024`.T](int("PORT")) |@|
         nonEmpty(string("DB_URL")).optional |@|
-        size[Greater[W.`2`.T]](list(long("LONGVALS")))
+        size[Greater[W.`2`.T]](list("LONGVALS")(long))
     )(
       RefinedProd.apply,
       RefinedProd.unapply

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -69,7 +69,7 @@ This support a list of values for a key.
 ```scala mdoc:silent
 case class ListConfig(ldap: String, port: List[Int], dburl: String)
 
-val listConfig = (string("LDAP") |@| list(int("PORT")) |@| string("DB_URL"))(ListConfig.apply, ListConfig.unapply)
+val listConfig = (string("LDAP") |@| list("PORT")(int) |@| string("DB_URL"))(ListConfig.apply, ListConfig.unapply)
 
 val multiMapSource =
   ConfigSource.fromMultiMap(

--- a/docs/usingconfigdescriptor/index.md
+++ b/docs/usingconfigdescriptor/index.md
@@ -126,19 +126,19 @@ To generate the documentation of the config, call `generateDocs`.
      NestedPath(
        "south",
        Both(
-         NestedPath("connection", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "South details"))),
-         NestedPath("port", ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "South details")))
+         NestedPath("connection", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string", "South details"))),
+         NestedPath("port", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type int", "South details")))
        )
      ),
      NestedPath(
        "east",
        Both(
-         NestedPath("connection", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "East details"))),
-         NestedPath("port", ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "East details")))
+         NestedPath("connection", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string", "East details"))),
+         NestedPath("port", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type int", "East details")))
        )
      )
    ),
-   NestedPath("appName", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string")))
+   NestedPath("appName", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string")))
  )
 ```
 
@@ -171,11 +171,11 @@ Right(
         Both(
           NestedPath(
             "connection",
-            ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "South details"), Some("abc.com"))
+            ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string", "South details"), Some("abc.com"))
           ),
           NestedPath(
             "port",
-            ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "South details"), Some("8111"))
+            ConfigDocs.Leaf(Sources(Set("constant")), List("value of type int", "South details"), Some("8111"))
           )
         )
       ),
@@ -184,16 +184,16 @@ Right(
         Both(
           NestedPath(
             "connection",
-            ConfigDocs.Leaf(Sources(List("constant")), List("value of type string", "East details"), Some("xyz.com"))
+            ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string", "East details"), Some("xyz.com"))
           ),
           NestedPath(
             "port",
-            ConfigDocs.Leaf(Sources(List("constant")), List("value of type int", "East details"), Some("8888"))
+            ConfigDocs.Leaf(Sources(Set("constant")), List("value of type int", "East details"), Some("8888"))
           )
         )
       )
     ),
-    NestedPath("appName", ConfigDocs.Leaf(Sources(List("constant")), List("value of type string"), Some("myApp")))
+    NestedPath("appName", ConfigDocs.Leaf(Sources(Set("constant")), List("value of type string"), Some("myApp")))
   )
 )
 ```

--- a/examples/src/main/scala/zio/config/examples/DefaultValueExample.scala
+++ b/examples/src/main/scala/zio/config/examples/DefaultValueExample.scala
@@ -32,19 +32,19 @@ object DefaultValueExample extends App {
         NestedPath(
           "HELLO",
           Leaf(
-            Sources(List(ConfigSource.SystemEnvironment)),
+            Sources(Set(ConfigSource.SystemEnvironment)),
             List("value of type string", "default value: xyz")
           )
         ),
         OneOf(
           NestedPath(
             "SOMETHING",
-            Leaf(Sources(List(ConfigSource.SystemEnvironment)), List("value of type string"))
+            Leaf(Sources(Set(ConfigSource.SystemEnvironment)), List("value of type string"))
           ),
           NestedPath(
             "PORT",
             Leaf(
-              Sources(List(ConfigSource.SystemEnvironment)),
+              Sources(Set(ConfigSource.SystemEnvironment)),
               List("value of type int", "default value: 1")
             )
           )
@@ -59,7 +59,7 @@ object DefaultValueExample extends App {
           NestedPath(
             "HELLO",
             Leaf(
-              Sources(List(SystemEnvironment)),
+              Sources(Set(SystemEnvironment)),
               List("value of type string", "default value: xyz"),
               Some("xyz")
             )
@@ -67,12 +67,12 @@ object DefaultValueExample extends App {
           OneOf(
             NestedPath(
               "SOMETHING",
-              Leaf(Sources(List(SystemEnvironment)), List("value of type string"), None)
+              Leaf(Sources(Set(SystemEnvironment)), List("value of type string"), None)
             ),
             NestedPath(
               "PORT",
               Leaf(
-                Sources(List(SystemEnvironment)),
+                Sources(Set(SystemEnvironment)),
                 List("value of type int", "default value: 1"),
                 Some("1")
               )

--- a/examples/src/main/scala/zio/config/examples/DocsExample.scala
+++ b/examples/src/main/scala/zio/config/examples/DocsExample.scala
@@ -17,12 +17,12 @@ object DocsExample extends App {
       Both(
         NestedPath(
           "PORT",
-          Leaf(Sources(Nil), List("value of type int", "Example: 8088", "Database related"))
+          Leaf(Sources(Set.empty), List("value of type int", "Example: 8088", "Database related"))
         ),
         NestedPath(
           "URL",
           Leaf(
-            Sources(Nil),
+            Sources(Set.empty),
             List("value of type string", "optional value", "Example: abc.com", "Database related")
           )
         )
@@ -36,7 +36,7 @@ object DocsExample extends App {
           NestedPath(
             "PORT",
             Leaf(
-              Sources(Nil),
+              Sources(Set.empty),
               List("value of type int", "Example: 8088", "Database related"),
               Some("1")
             )
@@ -44,7 +44,7 @@ object DocsExample extends App {
           NestedPath(
             "URL",
             Leaf(
-              Sources(Nil),
+              Sources(Set.empty),
               List("value of type string", "optional value", "Example: abc.com", "Database related"),
               Some("value")
             )

--- a/examples/src/main/scala/zio/config/examples/EitherExample.scala
+++ b/examples/src/main/scala/zio/config/examples/EitherExample.scala
@@ -1,9 +1,7 @@
 package zio.config.examples
 
 import zio.config.ConfigDescriptor._
-import zio.config.ReadError.{ FormatError, KeyStep, MissingValue, OrErrors }
-import zio.config._
-//import zio.config.ReadError._
+import zio.config.ReadError.{ FormatError, MissingValue, OrErrors, Step }
 import zio.config.{ ConfigSource, _ }
 
 object EitherExample extends App {
@@ -72,8 +70,8 @@ object EitherExample extends App {
         // OrErrors indicate that either fix the error with x1 or the error with x5
         OrErrors(
           List(
-            MissingValue(List(KeyStep("x1"))),
-            FormatError(List(KeyStep("x5")), ReadFunctions.parseErrorMessage("notadouble", "double"))
+            MissingValue(List(Step.Key("x1"))),
+            FormatError(List(Step.Key("x5")), ReadFunctions.parseErrorMessage("notadouble", "double"))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/EitherExample.scala
+++ b/examples/src/main/scala/zio/config/examples/EitherExample.scala
@@ -1,8 +1,8 @@
 package zio.config.examples
 
+import zio.config.ConfigDescriptor._
+import zio.config.ReadError.{ FormatError, KeyStep, MissingValue, OrErrors }
 import zio.config._
-import ConfigDescriptor._
-import zio.config.ReadError.{ FormatError, MissingValue, OrErrors }
 //import zio.config.ReadError._
 import zio.config.{ ConfigSource, _ }
 
@@ -72,8 +72,8 @@ object EitherExample extends App {
         // OrErrors indicate that either fix the error with x1 or the error with x5
         OrErrors(
           List(
-            MissingValue(Vector(Right("x1"))),
-            FormatError(Vector(Right("x5")), ReadFunctions.parseErrorMessage("notadouble", "double"))
+            MissingValue(List(KeyStep("x1"))),
+            FormatError(List(KeyStep("x5")), ReadFunctions.parseErrorMessage("notadouble", "double"))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
+++ b/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
@@ -24,8 +24,8 @@ object ErrorAccumulation extends App {
         // AndErrors indicate fix the errors associated with both envvar1 and OrError(envvar2 or envvar3)
         AndErrors(
           List(
-            MissingValue(List(KeyStep("envvar"))),
-            OrErrors(List(MissingValue(List(KeyStep("envvar2"))), MissingValue(List(KeyStep("envvar3")))))
+            MissingValue(List(Step.Key("envvar"))),
+            OrErrors(List(MissingValue(List(Step.Key("envvar2"))), MissingValue(List(Step.Key("envvar3")))))
           )
         )
       )
@@ -44,8 +44,8 @@ object ErrorAccumulation extends App {
       Left(
         AndErrors(
           List(
-            FormatError(List(KeyStep("envvar")), ReadFunctions.parseErrorMessage("wrong", "int")),
-            OrErrors(List(MissingValue(List(KeyStep("envvar2"))), MissingValue(List(KeyStep("envvar3")))))
+            FormatError(List(Step.Key("envvar")), ReadFunctions.parseErrorMessage("wrong", "int")),
+            OrErrors(List(MissingValue(List(Step.Key("envvar2"))), MissingValue(List(Step.Key("envvar3")))))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
+++ b/examples/src/main/scala/zio/config/examples/ErrorAccumulation.scala
@@ -24,8 +24,8 @@ object ErrorAccumulation extends App {
         // AndErrors indicate fix the errors associated with both envvar1 and OrError(envvar2 or envvar3)
         AndErrors(
           List(
-            MissingValue(Vector(Right("envvar"))),
-            OrErrors(List(MissingValue(Vector(Right("envvar2"))), MissingValue(Vector(Right("envvar3")))))
+            MissingValue(List(KeyStep("envvar"))),
+            OrErrors(List(MissingValue(List(KeyStep("envvar2"))), MissingValue(List(KeyStep("envvar3")))))
           )
         )
       )
@@ -44,8 +44,8 @@ object ErrorAccumulation extends App {
       Left(
         AndErrors(
           List(
-            FormatError(Vector(Right("envvar")), ReadFunctions.parseErrorMessage("wrong", "int")),
-            OrErrors(List(MissingValue(Vector(Right("envvar2"))), MissingValue(Vector(Right("envvar3")))))
+            FormatError(List(KeyStep("envvar")), ReadFunctions.parseErrorMessage("wrong", "int")),
+            OrErrors(List(MissingValue(List(KeyStep("envvar2"))), MissingValue(List(KeyStep("envvar3")))))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ListExample.scala
+++ b/examples/src/main/scala/zio/config/examples/ListExample.scala
@@ -17,7 +17,7 @@ object ListExample extends App with EitherImpureOps {
     )
 
   val config: ConfigDescriptor[String, String, PgmConfig] =
-    (string("xyz") |@| list(string("regions")))(PgmConfig.apply, PgmConfig.unapply)
+    (string("xyz") |@| list("regions")(string))(PgmConfig.apply, PgmConfig.unapply)
 
   val tree =
     ConfigSource.fromMultiMap(multiMap, "constant")

--- a/examples/src/main/scala/zio/config/examples/NestedConfigExample.scala
+++ b/examples/src/main/scala/zio/config/examples/NestedConfigExample.scala
@@ -45,9 +45,9 @@ object NestedConfigExample extends App {
             Both(
               NestedPath(
                 "connection",
-                Leaf(Sources(Nil), List("value of type string", "South details"))
+                Leaf(Sources(Set.empty), List("value of type string", "South details"))
               ),
-              NestedPath("port", Leaf(Sources(Nil), List("value of type int", "South details")))
+              NestedPath("port", Leaf(Sources(Set.empty), List("value of type int", "South details")))
             )
           ),
           NestedPath(
@@ -55,13 +55,13 @@ object NestedConfigExample extends App {
             Both(
               NestedPath(
                 "connection",
-                Leaf(Sources(Nil), List("value of type string", "East details"))
+                Leaf(Sources(Set.empty), List("value of type string", "East details"))
               ),
-              NestedPath("port", Leaf(Sources(Nil), List("value of type int", "East details")))
+              NestedPath("port", Leaf(Sources(Set.empty), List("value of type int", "East details")))
             )
           )
         ),
-        NestedPath("appName", Leaf(Sources(Nil), List("value of type string")))
+        NestedPath("appName", Leaf(Sources(Set.empty), List("value of type string")))
       )
   )
 
@@ -77,7 +77,7 @@ object NestedConfigExample extends App {
                 NestedPath(
                   "connection",
                   Leaf(
-                    Sources(Nil),
+                    Sources(Set.empty),
                     List("value of type string", "South details"),
                     Some("abc.com")
                   )
@@ -85,7 +85,7 @@ object NestedConfigExample extends App {
                 NestedPath(
                   "port",
                   Leaf(
-                    Sources(Nil),
+                    Sources(Set.empty),
                     List("value of type int", "South details"),
                     Some("8111")
                   )
@@ -98,7 +98,7 @@ object NestedConfigExample extends App {
                 NestedPath(
                   "connection",
                   Leaf(
-                    Sources(Nil),
+                    Sources(Set.empty),
                     List("value of type string", "East details"),
                     Some("xyz.com")
                   )
@@ -106,7 +106,7 @@ object NestedConfigExample extends App {
                 NestedPath(
                   "port",
                   Leaf(
-                    Sources(Nil),
+                    Sources(Set.empty),
                     List("value of type int", "East details"),
                     Some("8888")
                   )
@@ -116,7 +116,7 @@ object NestedConfigExample extends App {
           ),
           NestedPath(
             "appName",
-            Leaf(Sources(Nil), List("value of type string"), Some("myApp"))
+            Leaf(Sources(Set.empty), List("value of type string"), Some("myApp"))
           )
         )
       )

--- a/examples/src/main/scala/zio/config/examples/ReadWriteReportExample.scala
+++ b/examples/src/main/scala/zio/config/examples/ReadWriteReportExample.scala
@@ -80,14 +80,14 @@ object ReadWriteReportExample extends App {
               NestedPath(
                 "usr",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type string", "Example: some-user", "Prod Config")
                 )
               ),
               NestedPath(
                 "pwd",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type string", "optional value", "sec", "Prod Config")
                 )
               )
@@ -95,7 +95,7 @@ object ReadWriteReportExample extends App {
             NestedPath(
               "jhi",
               Leaf(
-                Sources(List("constant")),
+                Sources(Set("constant")),
                 List("value of type string", "optional value", "Ex: ghi", "Prod Config")
               )
             )
@@ -104,7 +104,7 @@ object ReadWriteReportExample extends App {
             NestedPath(
               "xyz",
               Leaf(
-                Sources(List("constant")),
+                Sources(Set("constant")),
                 List("value of type string", "optional value", "Ex: ha", "Prod Config")
               )
             ),
@@ -112,14 +112,14 @@ object ReadWriteReportExample extends App {
               NestedPath(
                 "abc",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type int", "optional value", "Ex: ha", "Prod Config")
                 )
               ),
               NestedPath(
                 "def",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type string", "optional value", "Ex: ha", "Prod Config")
                 )
               )
@@ -129,11 +129,11 @@ object ReadWriteReportExample extends App {
         Both(
           NestedPath(
             "auth_token",
-            Leaf(Sources(List("constant")), List("value of type string", "Prod Config"))
+            Leaf(Sources(Set("constant")), List("value of type string", "Prod Config"))
           ),
           NestedPath(
             "clientid",
-            Leaf(Sources(List("constant")), List("value of type string", "Prod Config"))
+            Leaf(Sources(Set("constant")), List("value of type string", "Prod Config"))
           )
         )
       )
@@ -149,7 +149,7 @@ object ReadWriteReportExample extends App {
                 NestedPath(
                   "usr",
                   Leaf(
-                    Sources(List("constant")),
+                    Sources(Set("constant")),
                     List("value of type string", "Example: some-user", "Prod Config"),
                     Some("v1")
                   )
@@ -157,7 +157,7 @@ object ReadWriteReportExample extends App {
                 NestedPath(
                   "pwd",
                   Leaf(
-                    Sources(List("constant")),
+                    Sources(Set("constant")),
                     List("value of type string", "optional value", "sec", "Prod Config"),
                     Some("v2")
                   )
@@ -166,7 +166,7 @@ object ReadWriteReportExample extends App {
               NestedPath(
                 "jhi",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type string", "optional value", "Ex: ghi", "Prod Config")
                 )
               )
@@ -175,7 +175,7 @@ object ReadWriteReportExample extends App {
               NestedPath(
                 "xyz",
                 Leaf(
-                  Sources(List("constant")),
+                  Sources(Set("constant")),
                   List("value of type string", "optional value", "Ex: ha", "Prod Config"),
                   Some("v3")
                 )
@@ -184,7 +184,7 @@ object ReadWriteReportExample extends App {
                 NestedPath(
                   "abc",
                   Leaf(
-                    Sources(List("constant")),
+                    Sources(Set("constant")),
                     List("value of type int", "optional value", "Ex: ha", "Prod Config"),
                     Some("1")
                   )
@@ -192,7 +192,7 @@ object ReadWriteReportExample extends App {
                 NestedPath(
                   "def",
                   Leaf(
-                    Sources(List("constant")),
+                    Sources(Set("constant")),
                     List("value of type string", "optional value", "Ex: ha", "Prod Config")
                   )
                 )
@@ -203,14 +203,14 @@ object ReadWriteReportExample extends App {
             NestedPath(
               "auth_token",
               Leaf(
-                Sources(List("constant")),
+                Sources(Set("constant")),
                 List("value of type string", "Prod Config")
               )
             ),
             NestedPath(
               "clientid",
               Leaf(
-                Sources(List("constant")),
+                Sources(Set("constant")),
                 List("value of type string", "Prod Config")
               )
             )

--- a/examples/src/main/scala/zio/config/examples/commandline/ComplexCommandLine.scala
+++ b/examples/src/main/scala/zio/config/examples/commandline/ComplexCommandLine.scala
@@ -42,7 +42,7 @@ object MorePatternsExample extends App {
 
   object AppConfig {
     val desc: ConfigDescriptor[String, String, AppConfig] =
-      (nested("conf") { SparkConfig.desc } |@| VaultConfig.desc |@| list(string("users")) |@| list(string("region")))(
+      (nested("conf") { SparkConfig.desc } |@| VaultConfig.desc |@| list("users")(string) |@| list("region")(string))(
         AppConfig.apply,
         AppConfig.unapply
       )

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -21,7 +21,7 @@ object RefinedReadConfig extends App {
       nonEmpty(string("LDAP")) |@|
         greaterEqual[W.`1024`.T](int("PORT")) |@|
         nonEmpty(string("DB_URL")).optional |@|
-        size[Greater[W.`2`.T]](list(long("LONGVALS")))
+        size[Greater[W.`2`.T]](list("LONGVALS")(long))
     )(
       RefinedProd.apply,
       RefinedProd.unapply

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigSimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigSimpleExample.scala
@@ -55,7 +55,7 @@ object TypesafeConfigSimpleExample extends App {
   val details = (string("name") |@| int("age"))(Details.apply, Details.unapply)
 
   val accountConfig =
-    (int("accountId").orElseEither(string("accountId")).optional |@| list(string("regions")) |@| nested("details")(
+    (int("accountId").orElseEither(string("accountId")).optional |@| list("regions")(string) |@| nested("details")(
       details
     ).optional)(
       Account.apply,
@@ -65,7 +65,7 @@ object TypesafeConfigSimpleExample extends App {
   val databaseConfig = (int("port").optional |@| string("url"))(Database.apply, Database.unapply)
 
   val awsDetailsConfig =
-    (nested("accounts")(list(accountConfig)) |@| nested("database")(databaseConfig) |@| list(int("users")))(
+    (nested("accounts")(list(accountConfig)) |@| nested("database")(databaseConfig) |@| list("users")(int))(
       AwsDetails.apply,
       AwsDetails.unapply
     )

--- a/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
@@ -129,9 +129,9 @@ object DeriveConfigDescriptor extends LowPriorityDeriveConfigDescriptor {
 
   /**
    * Leaks out path in simple cases, i.e.
-   * `list(string(path))` == `list(path)(string)` == `nested(path)(listOrSingle(string))`
+   * `legacyList(string(path))` == `list(path)(string)` == `nested(path)(list(string))`
    *
-   * `nested("a")(list(string("b")))` describes configuration `{a: { b: ["s1", "s2"] }}`
+   * `nested("a")(legacyList(string("b")))` describes configuration `{a: { b: ["s1", "s2"] }}`
    *
    * Allows scalar value instead of list
    * */

--- a/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
+++ b/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
@@ -34,7 +34,7 @@ object RefinedReadWriteRoundtripTest
               val p2 =
                 read(prodConfig(n) from ConfigSource.fromMap(envMap))
 
-              assert(p2)(helpers.assertErrors(_.size == 4))
+              assert(p2)(helpers.isErrors(hasField("size", _.size, equalTo(4))))
           }
         }
       )

--- a/typesafe/src/main/scala/zio/config/typesafe/TypeSafeConfigSource.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypeSafeConfigSource.scala
@@ -49,17 +49,11 @@ object TypeSafeConfigSource {
   private[config] def getPropertyTree(
     input: com.typesafe.config.Config
   ): Either[String, PropertyTree[String, String]] = {
-    def loopBoolean(value: Boolean) = Leaf(value.toString)
-    def loopNumber(value: Number)   = Leaf(value.toString)
-    val loopNull                    = PropertyTree.empty
-    def loopString(value: String)   = Leaf(value)
-
-    def loopList(values: List[ConfigValue]) = {
-      val list = values.map(loopAny)
-
-      if (list.isEmpty) PropertyTree.empty // FIXME incorrect empty Sequence() processing
-      else Sequence(list)
-    }
+    def loopBoolean(value: Boolean)         = Leaf(value.toString)
+    def loopNumber(value: Number)           = Leaf(value.toString)
+    val loopNull                            = PropertyTree.empty
+    def loopString(value: String)           = Leaf(value)
+    def loopList(values: List[ConfigValue]) = Sequence(values.map(loopAny))
 
     def loopConfig(config: ConfigObject) =
       Record(config.asScala.toVector.map { case (key, value) => key -> loopAny(value) }.toMap)

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -1,16 +1,30 @@
 package zio.config.typesafe
 
-import zio.test._
-import zio.test.Assertion._
-import zio.config.BaseSpec
-import TypesafeConfigSpecUtils._
 import zio.config.PropertyTree.{ Leaf, Record, Sequence }
-import zio.config._
+import zio.config.{ BaseSpec, _ }
 import zio.config.magnolia.DeriveConfigDescriptor._
+import zio.config.typesafe.TypesafeConfigSpecUtils._
+import zio.test.Assertion._
+import zio.test._
 
 object TypesafeConfigSpec
     extends BaseSpec(
       suite("TypesafeConfig")(
+        test("Read empty list") {
+          val res =
+            TypeSafeConfigSource.fromHoconString(
+              """
+                |a {
+                |  b = "s"
+                |  c = []
+                |}
+                |""".stripMargin
+            )
+
+          val expected = Record(Map("a" -> Record(Map("b" -> Leaf("s"), "c" -> Sequence(Nil)))))
+
+          assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
+        },
         test("Read mixed list") {
           val res =
             TypeSafeConfigSource.fromHoconString(
@@ -24,7 +38,7 @@ object TypesafeConfigSpec
 
           val expected = Record(Map("list" -> Sequence(List(Leaf("a"), Record(Map("b" -> Leaf("c")))))))
 
-          assert(res.map(_.getConfigValue(Vector.empty)))(isRight(equalTo(expected)))
+          assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
         },
         testM(
           "Read a complex hocon structure successfully"

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -66,10 +66,10 @@ object TypesafeConfigSpec
                             List(
                               C(
                                 List(
-                                  D(NonEmptyList(1, 1, 1), List("a", "b", "c")),
-                                  D(NonEmptyList(12, 12), List("d")),
-                                  D(NonEmptyList(14, 14), List("e")),
-                                  D(NonEmptyList(15, 15), List("f", "g"))
+                                  D(NonEmptyList(1, 1, 1), List("a", "b", "c"), None, Nil),
+                                  D(NonEmptyList(12, 12), List("d"), Some(Nil), List(Nil)),
+                                  D(NonEmptyList(14, 14), Nil, Some(List("a")), List(List(Nil))),
+                                  D(NonEmptyList(15, 15), List("f", "g"), Some(List("", "")), List(List(List("x"))))
                                 )
                               )
                             ),
@@ -80,10 +80,10 @@ object TypesafeConfigSpec
                             List(
                               C(
                                 List(
-                                  D(List(21, 21), List("af")),
-                                  D(List(22, 22), List("sa", "l")),
-                                  D(List(23, 23, 23), List("af", "l")),
-                                  D(List(24, 24, 24), List("l"))
+                                  D(List(21, 21), List("af"), None, Nil),
+                                  D(List(22, 22), List("sa", "l"), None, Nil),
+                                  D(List(23, 23, 23), List("af", "l"), Some(Nil), List(Nil)),
+                                  D(List(24, 24, 24), List("l"), Some(Nil), List(List(Nil)))
                                 )
                               )
                             ),
@@ -94,11 +94,11 @@ object TypesafeConfigSpec
                             List(
                               C(
                                 List(
-                                  D(List(31, 31), List("bb")),
-                                  D(List(32, 32), List("x")),
-                                  D(List(33, 33, 33), List("xx")),
-                                  D(List(31), List("b")),
-                                  D(List(37), List("e", "f", "g", "h", "i"))
+                                  D(List(31, 31), List("bb"), None, Nil),
+                                  D(List(32, 32), List("x"), None, Nil),
+                                  D(List(33, 33, 33), List("xx"), None, Nil),
+                                  D(Nil, List("b"), None, Nil),
+                                  D(List(37), List("e", "f", "g", "h", "i"), None, Nil)
                                 )
                               )
                             ),
@@ -123,7 +123,7 @@ object TypesafeConfigSpecUtils {
   final case class Y(z: String)
   final case class X(y: Y)
   final case class W(x: X)
-  final case class D(e: List[Int], vvv: List[String])
+  final case class D(e: List[Int], vvv: List[String], y: Option[List[String]], z: List[List[List[String]]])
   final case class C(d: List[D])
   final case class B(c: List[C], table: String, columns: List[String])
   final case class A(b: List[B], x: X, w: W)
@@ -143,24 +143,31 @@ object TypesafeConfigSpecUtils {
       |            vi : bi
       |            e: [1, 1, 1]
       |            vvv = [a, b, c]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [12,12]
       |            vvv = [d]
+      |            y = []
+      |            z = [[]]
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [14,14]
-      |            vvv = [e]
+      |            vvv = []
+      |            y = ["a"]
+      |            z = [[[]]]
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [15,15]
       |            vvv = [f, g]
+      |            y = ["", ""]
+      |            z = [[["x"]]]
       |          }
       |        ]
       |      }
@@ -178,24 +185,30 @@ object TypesafeConfigSpecUtils {
       |            vi : bi
       |            e: [21, 21]
       |            vvv = [af]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [22, 22]
       |            vvv = [sa, l]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [23, 23, 23]
       |            vvv = [af, l]
+      |            y = []
+      |            z = [[]]
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [24, 24, 24]
       |            vvv = [l]
+      |            y = []
+      |            z = [[[]]]
       |          }
       |        ]
       |      }
@@ -212,30 +225,35 @@ object TypesafeConfigSpecUtils {
       |            vi : bi
       |            e: [31, 31]
       |            vvv = [bb]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [32, 32]
       |            vvv = [x]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [33, 33, 33]
       |            vvv = [xx]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
-      |            e: [31]
+      |            e: []
       |            vvv = [b]
+      |            z = []
       |          }
       |          {
       |            ci : ki
       |            vi : bi
       |            e: [37]
       |            vvv = [e,f,g,h,i]
+      |            z = []
       |          }
       |        ]
       |      }

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -70,11 +70,13 @@ object TypesafeConfigSpec
                                   D(NonEmptyList(12, 12), List("d"), Some(Nil), List(Nil)),
                                   D(NonEmptyList(14, 14), Nil, Some(List("a")), List(List(Nil))),
                                   D(NonEmptyList(15, 15), List("f", "g"), Some(List("", "")), List(List(List("x"))))
-                                )
+                                ),
+                                Nil
                               )
                             ),
                             "some_name",
-                            List("aa")
+                            List("aa"),
+                            Nil
                           ),
                           B(
                             List(
@@ -84,11 +86,13 @@ object TypesafeConfigSpec
                                   D(List(22, 22), List("sa", "l"), None, Nil),
                                   D(List(23, 23, 23), List("af", "l"), Some(Nil), List(Nil)),
                                   D(List(24, 24, 24), List("l"), Some(Nil), List(List(Nil)))
-                                )
+                                ),
+                                Nil
                               )
                             ),
                             "some_name",
-                            List("a", "b", "c", "d", "e")
+                            List("a", "b", "c", "d", "e"),
+                            Nil
                           ),
                           B(
                             List(
@@ -99,15 +103,18 @@ object TypesafeConfigSpec
                                   D(List(33, 33, 33), List("xx"), None, Nil),
                                   D(Nil, List("b"), None, Nil),
                                   D(List(37), List("e", "f", "g", "h", "i"), None, Nil)
-                                )
+                                ),
+                                Nil
                               )
                             ),
                             "some_name",
-                            List("a")
+                            List("a"),
+                            Nil
                           )
                         ),
                         X(Y("k")),
-                        W(X(Y("k")))
+                        W(X(Y("k"))),
+                        Nil
                       )
                     )
                   )
@@ -124,9 +131,9 @@ object TypesafeConfigSpecUtils {
   final case class X(y: Y)
   final case class W(x: X)
   final case class D(e: List[Int], vvv: List[String], y: Option[List[String]], z: List[List[List[String]]])
-  final case class C(d: List[D])
-  final case class B(c: List[C], table: String, columns: List[String])
-  final case class A(b: List[B], x: X, w: W)
+  final case class C(d: List[D], mmm: List[D])
+  final case class B(c: List[C], table: String, columns: List[String], mm: List[C])
+  final case class A(b: List[B], x: X, w: W, m: List[B])
 
   //Fixme; Make it Gen
   val configString =
@@ -170,8 +177,10 @@ object TypesafeConfigSpecUtils {
       |            z = [[["x"]]]
       |          }
       |        ]
+      |        mmm = []
       |      }
       |    ]
+      |    mm = []
       |  }
       |  
       |  {
@@ -211,8 +220,10 @@ object TypesafeConfigSpecUtils {
       |            z = [[[]]]
       |          }
       |        ]
+      |        mmm = []
       |      }
       |    ]
+      |    mm = []
       |  }
       |   {
       |    table          : some_name
@@ -256,8 +267,10 @@ object TypesafeConfigSpecUtils {
       |            z = []
       |          }
       |        ]
+      |        mmm = []
       |      }
       |    ]
+      |    mm = []
       |  }
       |]
       |
@@ -275,5 +288,6 @@ object TypesafeConfigSpecUtils {
       | }
       |}
       |
+      |m = []
       |""".stripMargin
 }


### PR DESCRIPTION
`ReadFunctions` is significantly simplified.

`ReadFunctions` is simpler and more strict now. All existing use-cases (except for one) supported with combined `ConfigDescriptor`s by default.

## Main changes
- `ConfigDescriptor.Sequence` holds `ConfigSource`.
- `ConfigDescriptor.Source` can read only `Leaf` node.
- `ConfigDescriptor.Sequence` can read only `Sequence` node.
- No more errors with empty list parsing.
- We can use `List` as a first class value including `Option[List[T]]`, `List[List[T]]`, default values, etc.
- Results of `ConfigSource.fromMap` and `ConfigSource.fromCommandLineArgs` are simplified.
- We can distinguish scalar and list.

## Support for existing use cases
- `list(nested(path)(cfg))` is transformed to `list(path)(cfg)` under the hood.
- `list(path)(cfg)` accepts scalar value as a list, i.e. `list("a")(string)` can parse both `a = ["v"]` and `a = "v"`. This is used in tests for `fromCommandLineArgs`.

## Broken use case
`string(path)` won't accept list by default. There is method `first` that consumes both scalar value and lists and returns first value: `first(path)(string)`

## `Either[String, List[String]]`
We can distinguish scalars and lists.
Now both `Either[String, List[String]]` and `Either[List[String], String]` make sense. On `master` any list descriptor can consume scalar and any scalar descriptor can consume list.
In this PR scalar descriptors can't consume lists by default and there is a strict version of list: `listStrict`.

## Corner cases
Nested lists are supported. We can even parse lists with empty list inside ( `path = [[]]` ) as `List(Nil)` and it's quite easy to create a parser for nested lists with single field objects: `path = [[{a = "b"}]]`.
For list of corner cases with descriptors see `ListsCornerCasesTest.scala`.

## Magnolia
`zio-config-magnolia` support for `Option[NonEmptyList[T]]` is fixed! It won't assumes that `descr.optional` can recover from `ConversionError` any more.
**Reason:** `zio-config-refined` assumes that `descr.optional` can't recover from `ConversionError`.
I suspect both work on `master` due to inconsistency in `descr.optional` behavior with lists.

This PR fixes `List` support, so there is no need for `Option[NonEmptyList[T]]` support any way, but we still can have it.