### PR TITLE
fix derivation

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -15,5 +15,6 @@ optIn.annotationNewlines = true
 rewrite.rules = [SortImports, RedundantBraces]
 project.excludeFilters = [
   "core/src/main/scala/zio/config/ProductBuilder.scala",
-  "core/src/test/scala/zio/config/ProductBuilderTest.scala"
+  "core/src/test/scala/zio/config/ProductBuilderTest.scala",
+  "magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala"
 ]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -15,6 +15,5 @@ optIn.annotationNewlines = true
 rewrite.rules = [SortImports, RedundantBraces]
 project.excludeFilters = [
   "core/src/main/scala/zio/config/ProductBuilder.scala",
-  "core/src/test/scala/zio/config/ProductBuilderTest.scala",
-  "magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala"
+  "core/src/test/scala/zio/config/ProductBuilderTest.scala"
 ]

--- a/core/src/main/scala/zio/config/ConfigDescriptor.scala
+++ b/core/src/main/scala/zio/config/ConfigDescriptor.scala
@@ -159,8 +159,11 @@ object ConfigDescriptor {
 
   def byte(path: String): ConfigDescriptor[String, String, Byte] = nested(path)(byte)
 
-  def collectAll[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] =
-    sequence(configList)
+  def collectAll[K, V, A](
+    head: ConfigDescriptor[K, V, A],
+    tail: ConfigDescriptor[K, V, A]*
+  ): ConfigDescriptor[K, V, List[A]] =
+    sequence(head, tail: _*)({ case (a, t) => a :: t }, l => l.headOption.map(h => (h, l.tail)))
 
   val double: ConfigDescriptor[String, String, Double] =
     ConfigDescriptor.Source(ConfigSource.empty, PropertyType.DoubleType) ?? "value of type double"
@@ -228,18 +231,21 @@ object ConfigDescriptor {
   def nested[K, V, A](path: K)(desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, A] =
     ConfigDescriptor.Nested(path, desc)
 
-  def sequence[K, V, A](configList: ::[ConfigDescriptor[K, V, A]]): ConfigDescriptor[K, V, ::[A]] = {
-    val reversed = configList.reverse
-    reversed.tail.foldLeft[ConfigDescriptor[K, V, ::[A]]](
-      reversed.head.xmap((a: A) => ::(a, Nil), (b: ::[A]) => b.head)
+  def sequence[K, V, A](
+    head: ConfigDescriptor[K, V, A],
+    tail: ConfigDescriptor[K, V, A]*
+  ): ConfigDescriptor[K, V, (A, List[A])] =
+    tail.reverse.foldLeft[ConfigDescriptor[K, V, (A, List[A])]](
+      head.xmap((a: A) => (a, Nil), (b: (A, List[A])) => b._1)
     )(
-      (b: ConfigDescriptor[K, V, ::[A]], a: ConfigDescriptor[K, V, A]) =>
+      (b: ConfigDescriptor[K, V, (A, List[A])], a: ConfigDescriptor[K, V, A]) =>
         b.xmapEither2(a)(
-          (as: ::[A], a: A) => Right(::(a, as)),
-          (t: ::[A]) => Right((::(t.tail.head, t.tail.tail), t.head))
+          { case ((first, tail), a)    => Right((first, a :: tail)) }, {
+            case (_, Nil)              => Left("Invalid list length")
+            case (first, head :: tail) => Right(((first, tail), head))
+          }
         )
     )
-  }
 
   val short: ConfigDescriptor[String, String, Short] =
     ConfigDescriptor.Source(ConfigSource.empty, PropertyType.ShortType) ?? "value of type short"

--- a/core/src/main/scala/zio/config/package.scala
+++ b/core/src/main/scala/zio/config/package.scala
@@ -4,13 +4,6 @@ package object config extends ReadFunctions with WriteFunctions with ConfigDocsF
 
   type Config[A] = Has[A]
 
-  type NonEmptyList[A] = ::[A]
-
-  object NonEmptyList {
-    def apply[A](a: A*) =
-      ::(a.head, a.tail.toList)
-  }
-
   final def config[A](implicit tagged: Tagged[A]): ZIO[Config[A], Nothing, A] =
     ZIO.access(_.get)
 

--- a/core/src/test/scala/zio/config/CollectAllRoundtripTest.scala
+++ b/core/src/test/scala/zio/config/CollectAllRoundtripTest.scala
@@ -28,10 +28,7 @@ object CollectAllRoundtripTest
               val inputSource: Map[String, String] =
                 groups.flatMap(_.toMap.toList).toMap
 
-              val config =
-                ConfigDescriptor.sequence(
-                  consOfConfig
-                )
+              val config = ConfigDescriptor.sequence(consOfConfig.head, consOfConfig.tail: _*)
 
               val readAndWrite: ZIO[Any, Any, PropertyTree[String, String]] =
                 for {

--- a/docs/automatic/index.md
+++ b/docs/automatic/index.md
@@ -13,7 +13,7 @@ Take a look at the magnolia examples in `zio-config`
 
 ```scala mdoc:silent
 
-import zio.config.magnolia.DeriveConfigDescriptor
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
 import zio.config.typesafe.TypeSafeConfigSource
 
@@ -76,11 +76,11 @@ object CoproductSealedTraitExample extends App {
       )
       .loadOrThrow
 
-  assert(read(DeriveConfigDescriptor[X] from aHoconSource) == Right(A))
-  assert(read(DeriveConfigDescriptor[X] from bHoconSource) == Right(B))
-  assert(read(DeriveConfigDescriptor[X] from cHoconSource) == Right(C))
+  assert(read(descriptor[X] from aHoconSource) == Right(A))
+  assert(read(descriptor[X] from bHoconSource) == Right(B))
+  assert(read(descriptor[X] from cHoconSource) == Right(C))
   assert(
-    read(DeriveConfigDescriptor[X] from dHoconSource) == Right(
+    read(descriptor[X] from dHoconSource) == Right(
       D(Detail("ff", "ll", Region("strath", "syd")))
     )
   )

--- a/docs/configdescriptor/index.md
+++ b/docs/configdescriptor/index.md
@@ -364,9 +364,8 @@ Note that, you can write this back as well. This is discussed in write section
  def database(i: Int) = 
    (string(s"${i}_URL") |@| int(s"${i}_PORT"))(Database, Database.unapply)
 
- val list: ConfigDescriptor[String, String, ::[Database]] =
-   collectAll(::(database(0), (1 to 10).map(database).toList)) 
-   // collectAll takes `::` (cons, representing non-empty list) instead of a `List`.
+ val list: ConfigDescriptor[String, String, List[Database]] =
+   collectAll(database(0), (1 to 10).map(database): _*) 
 
 ```
 Running this to ZIO will result in non empty list of database

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -80,9 +80,9 @@ there is a separate module called `zio-config-magnolia`.
 
 ```scala mdoc:silent
 
-import zio.config.magnolia.DeriveConfigDescriptor
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 
-val myConfigAutomatic = DeriveConfigDescriptor[MyConfig]
+val myConfigAutomatic = descriptor[MyConfig]
 // ConfigDescriptor[String, String, MyConfig]
 
 ```

--- a/examples/src/main/scala/zio/config/examples/CollectAllExample.scala
+++ b/examples/src/main/scala/zio/config/examples/CollectAllExample.scala
@@ -21,8 +21,8 @@ object CollectAllExample extends App with EitherImpureOps {
           (int(s"${group}_VARIABLE1") |@| int(s"${group}_VARIABLE2").optional)(Variables.apply, Variables.unapply)
       )
 
-  val configOfList: ConfigDescriptor[String, String, ::[Variables]] =
-    ConfigDescriptor.collectAll(::(listOfConfig.head, listOfConfig.tail))
+  val configOfList: ConfigDescriptor[String, String, List[Variables]] =
+    ConfigDescriptor.collectAll(listOfConfig.head, listOfConfig.tail: _*)
 
   val map =
     Map(
@@ -36,11 +36,11 @@ object CollectAllExample extends App with EitherImpureOps {
     )
 
   // loadOrThrow here is only for the purpose of example
-  val result: ::[Variables]                 = read(configOfList from ConfigSource.fromMap(map, "constant")).loadOrThrow
+  val result: List[Variables]               = read(configOfList from ConfigSource.fromMap(map, "constant")).loadOrThrow
   val written: PropertyTree[String, String] = write(configOfList, result).loadOrThrow
 
   assert(
-    result == ::(Variables(1, Some(2)), List(Variables(3, Some(4)), Variables(5, Some(6)), Variables(7, None)))
+    result == List(Variables(1, Some(2)), Variables(3, Some(4)), Variables(5, Some(6)), Variables(7, None))
   )
 
   assert(

--- a/examples/src/main/scala/zio/config/examples/commandline/NestedExample.scala
+++ b/examples/src/main/scala/zio/config/examples/commandline/NestedExample.scala
@@ -1,7 +1,7 @@
 package zio.config.examples.commandline
 
 import zio.config.ConfigSource
-import zio.config.magnolia.DeriveConfigDescriptor
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config._
 
 object NestedExample extends App {
@@ -18,7 +18,7 @@ object NestedExample extends App {
   final case class A(conf: SparkConf, key3: String)
 
   assert(
-    read(DeriveConfigDescriptor[A] from source) == Right(
+    read(descriptor[A] from source) == Right(
       A(SparkConf("v1", "v2"), "v3")
     )
   )
@@ -33,7 +33,7 @@ object NestedExample extends App {
     ConfigSource.fromCommandLineArgs(cmdLineArgsAlternative.split(' ').toList)
 
   assert(
-    read(DeriveConfigDescriptor[A] from source2) == Right(
+    read(descriptor[A] from source2) == Right(
       A(SparkConf("v1", "v2"), "v3")
     )
   )
@@ -54,7 +54,7 @@ object NestedExample extends App {
     ConfigSource.fromCommandLineArgs(awsCmdLineArgs.split(' ').toList, keyDelimiter = Some('.'))
 
   assert(
-    read(DeriveConfigDescriptor[AppConfig] from source3) == Right(
+    read(descriptor[AppConfig] from source3) == Right(
       AppConfig(AwsConfig(KinesisConfig("v1", "v2"), S3Config("v3", "v4")), "jo")
     )
   )
@@ -71,7 +71,7 @@ object NestedExample extends App {
     ConfigSource.fromCommandLineArgs(awsCmdLineArgs2.split(' ').toList, keyDelimiter = Some('.'))
 
   assert(
-    read(DeriveConfigDescriptor[AppConfig] from source4) == Right(
+    read(descriptor[AppConfig] from source4) == Right(
       AppConfig(AwsConfig(KinesisConfig("v1", "v2"), S3Config("v3", "v4")), "jo")
     )
   )

--- a/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
@@ -1,7 +1,7 @@
 package zio.config.examples.commandline
 
 import zio.config.ConfigSource
-import zio.config.magnolia.DeriveConfigDescriptor
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config._, ConfigDescriptor._
 
 object SimpleExample extends App {
@@ -14,7 +14,7 @@ object SimpleExample extends App {
   final case class A(key1: String, key2: String)
 
   assert(
-    read(DeriveConfigDescriptor[A] from ConfigSource.fromCommandLineArgs(cmdLineArgs.split(' ').toList)) == Right(
+    read(descriptor[A] from ConfigSource.fromCommandLineArgs(cmdLineArgs.split(' ').toList)) == Right(
       A("value1", "value2")
     )
   )

--- a/examples/src/main/scala/zio/config/examples/magnolia/CoproductSealedTraitExample.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/CoproductSealedTraitExample.scala
@@ -1,11 +1,10 @@
 package zio.config.examples.magnolia
 
 import zio.config._
-import zio.config.magnolia.DeriveConfigDescriptor._
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.ConfigSource
 import zio.config.PropertyTree._
 import zio.config.examples.typesafe.EitherImpureOps
-import zio.config.magnolia.DeriveConfigDescriptor
 
 object CoproductSealedTraitExample extends App with EitherImpureOps {
 
@@ -19,11 +18,11 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
   case class Detail(firstName: String, lastName: String, region: Region)
   case class Region(suburb: String, city: String)
 
-  println(read(DeriveConfigDescriptor[X] from ConfigSource.fromMap(Map("x" -> "b"))))
+  println(read(descriptor[X] from ConfigSource.fromMap(Map("x" -> "b"))))
 
-  assert(read(DeriveConfigDescriptor[X] from ConfigSource.fromMap(Map("x" -> "a"))) == Right(A))
-  assert(read(DeriveConfigDescriptor[X] from ConfigSource.fromMap(Map("x" -> "b"))) == Right(B))
-  assert(read(DeriveConfigDescriptor[X] from ConfigSource.fromMap(Map("x" -> "c"))) == Right(C))
+  assert(read(descriptor[X] from ConfigSource.fromMap(Map("x" -> "a"))) == Right(A))
+  assert(read(descriptor[X] from ConfigSource.fromMap(Map("x" -> "b"))) == Right(B))
+  assert(read(descriptor[X] from ConfigSource.fromMap(Map("x" -> "c"))) == Right(C))
   assert(
     read(
       descriptor[X] from ConfigSource.fromMap(
@@ -56,7 +55,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
   )
 
   assert(
-    write(DeriveConfigDescriptor[X], D(Detail("ff", "ll", Region("strath", "syd")))) ==
+    write(descriptor[X], D(Detail("ff", "ll", Region("strath", "syd")))) ==
       Right(
         Record(
           Map(
@@ -80,7 +79,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
       )
   )
 
-  assert(write(DeriveConfigDescriptor[X], A) == Right(Record(Map("x" -> Leaf("a")))))
-  assert(write(DeriveConfigDescriptor[X], B) == Right(Record(Map("x" -> Leaf("b")))))
-  assert(write(DeriveConfigDescriptor[X], C) == Right(Record(Map("x" -> Leaf("c")))))
+  assert(write(descriptor[X], A) == Right(Record(Map("x" -> Leaf("a")))))
+  assert(write(descriptor[X], B) == Right(Record(Map("x" -> Leaf("b")))))
+  assert(write(descriptor[X], C) == Right(Record(Map("x" -> Leaf("c")))))
 }

--- a/examples/src/main/scala/zio/config/examples/magnolia/Simple.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/Simple.scala
@@ -1,9 +1,9 @@
 package zio.config.examples.magnolia
 
-import zio.config.examples.typesafe.{ EitherImpureOps }
-import zio.config.magnolia.DeriveConfigDescriptor
-import zio.config.typesafe.TypeSafeConfigSource
 import zio.config._
+import zio.config.examples.typesafe.EitherImpureOps
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+import zio.config.typesafe.TypeSafeConfigSource
 
 sealed trait X
 case object A                                 extends X
@@ -46,7 +46,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[CfgCfg] from TypeSafeConfigSource.fromHoconString(s1).loadOrThrow) == Right(
+    read(descriptor[CfgCfg] from TypeSafeConfigSource.fromHoconString(s1).loadOrThrow) == Right(
       CfgCfg(Cfg(C("b", G("hi"))), 1, "l")
     )
   )
@@ -59,7 +59,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s2).loadOrThrow) == Right(Cfg(A))
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s2).loadOrThrow) == Right(Cfg(A))
   )
 
   val s3 =
@@ -70,7 +70,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s3).loadOrThrow) == Right(Cfg(B))
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s3).loadOrThrow) == Right(Cfg(B))
   )
 
   val s4 =
@@ -91,7 +91,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s4).loadOrThrow) == Right(Cfg(D(Z("1"))))
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s4).loadOrThrow) == Right(Cfg(D(Z("1"))))
   )
 
   val s5 =
@@ -108,7 +108,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s5).loadOrThrow) == Right(Cfg(E("1", 2)))
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s5).loadOrThrow) == Right(Cfg(E("1", 2)))
   )
 
   val s6 =
@@ -131,7 +131,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s6).loadOrThrow) == Right(
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s6).loadOrThrow) == Right(
       Cfg(F("1", None, Z("2")))
     )
   )
@@ -157,7 +157,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(DeriveConfigDescriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s7).loadOrThrow) == Right(
+    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s7).loadOrThrow) == Right(
       Cfg(F("1", Some(2), Z("2")))
     )
   )

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductSealedTraitExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductSealedTraitExample.scala
@@ -3,7 +3,6 @@ package zio.config.examples.typesafe
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
 import zio.config.typesafe.TypeSafeConfigSource
-import zio.config.magnolia.DeriveConfigDescriptor
 
 object CoproductSealedTraitExample extends App with EitherImpureOps {
 
@@ -64,9 +63,9 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
       )
       .loadOrThrow
 
-  assert(read(DeriveConfigDescriptor[X] from aHoconSource) == Right(A))
-  assert(read(DeriveConfigDescriptor[X] from bHoconSource) == Right(B))
-  assert(read(DeriveConfigDescriptor[X] from cHoconSource) == Right(C))
+  assert(read(descriptor[X] from aHoconSource) == Right(A))
+  assert(read(descriptor[X] from bHoconSource) == Right(B))
+  assert(read(descriptor[X] from cHoconSource) == Right(C))
   assert(
     read(descriptor[X] from dHoconSource) == Right(
       D(Detail("ff", "ll", Region("strath", "syd")))

--- a/examples/src/main/scala/zio/config/examples/typesafe/ListExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/ListExample.scala
@@ -3,11 +3,8 @@ package zio.config.examples.typesafe
 import zio.config._
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.typesafe.TypeSafeConfigSource
-import zio.config.typesafe._
 
-// Why Maybe[NonEmptyList] could be the right thing to do, stays as a limitation to zio-config:
-// https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
-object NonEmptyListExample extends App with EitherImpureOps {
+object ListExample extends App with EitherImpureOps {
   val configString =
     """
       |b = [
@@ -162,10 +159,10 @@ object NonEmptyListExample extends App with EitherImpureOps {
             C(
               List(
                 // NonEmptyList is simply scala.:: which is a List. However, if the list was empty you get a error
-                D(NonEmptyList(1, 1, 1), List("a", "b", "c")),
-                D(NonEmptyList(12, 12), List("d")),
-                D(NonEmptyList(14, 14), List("e")),
-                D(NonEmptyList(15, 15), List("f", "g"))
+                D(List(1, 1, 1), List("a", "b", "c")),
+                D(List(12, 12), List("d")),
+                D(List(14, 14), List("e")),
+                D(List(15, 15), List("f", "g"))
               )
             )
           ),
@@ -326,14 +323,14 @@ object NonEmptyListExample extends App with EitherImpureOps {
   final case class Extra2(
     ci: String,
     vi: Either[Int, Either[Long, Either[Double, Either[Float, String]]]],
-    lst: Option[NonEmptyList[Int]],
-    vvv: Option[NonEmptyList[Int]]
+    lst: List[Int],
+    vvv: Option[List[Int]]
   )
-  final case class Extra(hi: String, bi: String, r: Option[NonEmptyList[Extra2]])
+  final case class Extra(hi: String, bi: String, r: List[Extra2])
   final case class Details(
     table: String,
-    columns: Option[NonEmptyList[String]],
-    extraDetails: Option[NonEmptyList[Extra]]
+    columns: List[String],
+    extraDetails: List[Extra]
   )
   final case class ExportDetails(exportDetails: List[Details], database: Database)
   final case class Port(va: String)
@@ -352,43 +349,37 @@ object NonEmptyListExample extends App with EitherImpureOps {
           List(
             Details(
               "some_name",
-              Some(::("a", List("b", "c", "d"))),
-              Some(
-                NonEmptyList(
-                  Extra(
-                    "di",
-                    "ci",
-                    Some(
-                      NonEmptyList(
-                        Extra2("ki", Right(Right(Right(Right("bi")))), Some(NonEmptyList(1, 1, 1)), None),
-                        Extra2("ki", Right(Right(Left(1.0882121))), Some(NonEmptyList(1, 2, 1)), None),
-                        Extra2("ki", Left(3), Some(NonEmptyList(1, 3, 5)), Some(NonEmptyList(1, 2, 3)))
-                      )
-                    )
-                  ),
-                  Extra(
-                    "di",
-                    "ci",
-                    Some(
-                      NonEmptyList(
-                        Extra2("ki", Right(Right(Right(Right("bi")))), Some(NonEmptyList(1, 1, 1)), None),
-                        Extra2("ki", Right(Right(Left(1.0882121))), Some(NonEmptyList(1, 2, 1)), None),
-                        Extra2("ki", Left(3), Some(NonEmptyList(1, 3, 5)), Some(NonEmptyList(1, 2, 3)))
-                      )
-                    )
-                  ),
-                  Extra("di", "ci", None)
-                )
+              List("a", "b", "c", "d"),
+              List(
+                Extra(
+                  "di",
+                  "ci",
+                  List(
+                    Extra2("ki", Right(Right(Right(Right("bi")))), List(1, 1, 1), Some(Nil)),
+                    Extra2("ki", Right(Right(Left(1.0882121))), List(1, 2, 1), None),
+                    Extra2("ki", Left(3), List(1, 3, 5), Some(List(1, 2, 3)))
+                  )
+                ),
+                Extra(
+                  "di",
+                  "ci",
+                  List(
+                    Extra2("ki", Right(Right(Right(Right("bi")))), List(1, 1, 1), Some(Nil)),
+                    Extra2("ki", Right(Right(Left(1.0882121))), List(1, 2, 1), None),
+                    Extra2("ki", Left(3), List(1, 3, 5), Some(List(1, 2, 3)))
+                  )
+                ),
+                Extra("di", "ci", Nil)
               )
             ),
             Details(
               "some_name1",
-              None,
-              Some(NonEmptyList(Extra("di", "ci", None), Extra("di", "ci", None), Extra("di", "ci", None)))
+              Nil,
+              List(Extra("di", "ci", Nil), Extra("di", "ci", Nil), Extra("di", "ci", Nil))
             ),
-            Details("some_name1", None, None),
-            Details("some_name2", None, None),
-            Details("some_name2", None, None)
+            Details("some_name1", Nil, Nil),
+            Details("some_name2", Nil, Nil),
+            Details("some_name2", Nil, Nil)
           ),
           Database(Port("ba"))
         )

--- a/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/DeriveConfigDescriptor.scala
@@ -3,18 +3,17 @@ package zio.config.magnolia
 import java.net.URI
 
 import magnolia._
-import zio.config.ConfigDescriptor
 import zio.config.ConfigDescriptor._
+import zio.config.{ ConfigDescriptor, ConfigSource, PropertyType }
 
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 import scala.language.experimental.macros
-import scala.util.{ Failure, Success }
 
 /**
- * DeriveConfigDescriptor[Config] gives an automatic ConfigDescriptor for the case class Config
- * given each field in the case class has an instance of DeriveConfigDescriptor
+ * DeriveConfigDescriptor.descriptor[Config] gives an automatic ConfigDescriptor for the case class Config recursively
  *
- * DeriveConfigDescriptor[X] gives an automatic ConfigDescriptor for the sealed trait X (coproduct)
- * given each term in the coproduct has an instance of DeriveConfigDescriptor
+ * DeriveConfigDescriptor.descriptor[X] gives an automatic ConfigDescriptor for the sealed trait X (coproduct)
  *
  * {{{
  *
@@ -22,294 +21,245 @@ import scala.util.{ Failure, Success }
  *    final case class Config(username: String, age: Int)
  *
  *    // should work with no additional code
- *    val description = DeriveConfigDescriptor[Config]
+ *    val description = descriptor[Config]
  *
  *    val config = Config.fromSystemEnv(description)
  *
- * Please find more (complex) examples in the examples module in zio-config
- *
  * }}}
+ *
+ *
+ * Please find more (complex) examples in the examples module in zio-config
  */
-trait DeriveConfigDescriptor[A] { self =>
-  def getDescription(path: Option[String], parentClass: Option[String]): ConfigDescriptor[String, String, A]
+object DeriveConfigDescriptor extends DeriveConfigDescriptor {
+  def mapClassName(name: String): String = toSnakeCase(name)
+  def mapFieldName(name: String): String = name
 
-  def xmap[B](f: A => B)(g: B => A): DeriveConfigDescriptor[B] =
-    xmapEither(a => Right(f(a)))(b => Right(g(b)))
-
-  def xmapEither[B](f: A => Either[String, B])(g: B => Either[String, A]): DeriveConfigDescriptor[B] =
-    new DeriveConfigDescriptor[B] {
-      override def getDescription(
-        path: Option[String],
-        parentClass: Option[String]
-      ): ConfigDescriptor[String, String, B] =
-        self.getDescription(path, parentClass).xmapEither(a => f(a), (b: B) => g(b))
-    }
-}
-
-trait LowPriorityDeriveConfigDescriptor {
-  implicit def opt[A](implicit ev: DeriveConfigDescriptor[A]): DeriveConfigDescriptor[Option[A]] =
-    (a, b) => ev.getDescription(a, b).optional
-}
-
-object DeriveConfigDescriptor extends LowPriorityDeriveConfigDescriptor {
+  val wrapSealedTraitClasses: Boolean = true
+  val wrapSealedTraits: Boolean       = true
 
   /**
-   * DeriveConfigDescriptor[Config] gives an automatic ConfigDescriptor for the case class Config
-   * given each field in the case class has an instance of DeriveConfigDescriptor
-   *
-   * DeriveConfigDescriptor[X] gives an automatic ConfigDescriptor for the sealed trait X (coproduct)
-   * given each term in the coproduct has an instance of DeriveConfigDescriptor
-   *
-   * {{{
-   *
-   *    // Given
-   *    final case class Config(username: String, age: Int)
-   *
-   *    // should work with no additional code
-   *    val description = DeriveConfigDescriptor[Config]
-   *
-   *    val config = Config.fromSystemEnv(description)
-   *
-   * }}}
-   *
-   * Please find more (complex) examples in the examples module in zio-config
-   */
-  def apply[T](implicit ev: DeriveConfigDescriptor[T]): ConfigDescriptor[String, String, T] =
-    ev.getDescription(None, None)
-
-  /**
-   * DeriveConfigDescriptor.descriptor[Config] gives an automatic ConfigDescriptor for the case class Config
-   * given each field in the case class has an instance of DeriveConfigDescriptor
-   *
-   * DeriveConfigDescriptor[X] gives an automatic ConfigDescriptor for the sealed trait X (coproduct)
-   * given each term in the coproduct has an instance of DeriveConfigDescriptor
-   *
-   * {{{
-   *
-   *    // Given
-   *    final case class Config(username: String, age: Int)
-   *
-   *    // should work with no additional code
-   *    val description = DeriveConfigDescriptor[Config]
-   *
-   *    val config = Config.fromSystemEnv(description)
-   *
-   * }}}
-   *
-   * Please find more (complex) examples in the examples module in zio-config
-   */
-  def descriptor[T](implicit ev: DeriveConfigDescriptor[T]): ConfigDescriptor[String, String, T] =
-    ev.getDescription(None, None)
-
-  def instance[T](f: String => ConfigDescriptor[String, String, T]): DeriveConfigDescriptor[T] =
-    new DeriveConfigDescriptor[T] {
-      override def getDescription(
-        path: Option[String],
-        parentClass: Option[String]
-      ): ConfigDescriptor[String, String, T] =
-        path.fold(
-          string.xmapEither[T](
-            _ => Left("unable to fetch the primitive without a path"),
-            (_: T) => Left("unable to write the primitive back to a config source without a path")
-          )
-        )(f)
-    }
-
-  implicit val stringDesc: DeriveConfigDescriptor[String]         = instance(string)
-  implicit val booleanDesc: DeriveConfigDescriptor[Boolean]       = instance(boolean)
-  implicit val byteDesc: DeriveConfigDescriptor[Byte]             = instance(byte)
-  implicit val shortDesc: DeriveConfigDescriptor[Short]           = instance(short)
-  implicit val intDesc: DeriveConfigDescriptor[Int]               = instance(int)
-  implicit val longDesc: DeriveConfigDescriptor[Long]             = instance(long)
-  implicit val bigIntDesc: DeriveConfigDescriptor[BigInt]         = instance(bigInt)
-  implicit val floatDesc: DeriveConfigDescriptor[Float]           = instance(float)
-  implicit val doubleDesc: DeriveConfigDescriptor[Double]         = instance(double)
-  implicit val bigDecimalDesc: DeriveConfigDescriptor[BigDecimal] = instance(bigDecimal)
-  implicit val uriDesc: DeriveConfigDescriptor[URI]               = instance(uri)
-
-  /**
-   * Leaks out path in simple cases, i.e.
-   * `legacyList(string(path))` == `list(path)(string)` == `nested(path)(list(string))`
-   *
-   * `nested("a")(legacyList(string("b")))` describes configuration `{a: { b: ["s1", "s2"] }}`
-   *
-   * Allows scalar value instead of list
+   * By default this method is not implicit to allow custom non-recursive derivation
    * */
-  def legacyList[K, V, A](desc: ConfigDescriptor[K, V, A]): ConfigDescriptor[K, V, List[A]] = {
-    def extractPath(cfg: ConfigDescriptor[K, V, A]): Option[(K, ConfigDescriptor[K, V, A])] = cfg match {
-      case Describe(config, message) =>
-        extractPath(config).map { case (path, inner) => (path, Describe(inner, message)) }
-      case Nested(path, config) => Some((path, config))
-      case _                    => None
-    }
+  override implicit def descriptor[T: NeedsDerive]: Descriptor[T] = macro DescriptorMacro.gen[T]
+}
 
-    extractPath(desc) match {
-      case Some((path, inner)) => list(path)(inner)
-      case None                => list(desc)
-    }
+/**
+ * Non-recursive derivation
+ *
+ * */
+object NonRecursiveDerivation extends DeriveConfigDescriptor {
+  def mapClassName(name: String): String = toSnakeCase(name)
+  def mapFieldName(name: String): String = name
+
+  val wrapSealedTraitClasses: Boolean = true
+  val wrapSealedTraits: Boolean       = true
+}
+
+trait DeriveConfigDescriptor { self =>
+
+  case class ConstantString(value: String) extends PropertyType[String, String] {
+    def read(propertyValue: String): Either[PropertyType.PropertyReadError[String], String] =
+      if (propertyValue == value) Right(value)
+      else Left(PropertyType.PropertyReadError(propertyValue, s"constant string '$value'"))
+    def write(a: String): String = a
   }
 
-  implicit def optNonEmptyList[A](implicit ev: DeriveConfigDescriptor[A]): DeriveConfigDescriptor[Option[::[A]]] =
-    (a, b) =>
-      legacyList(ev.getDescription(a, b)).optional.xmap(
-        {
-          case None | Some(Nil)   => None
-          case Some(head :: tail) => Some(::(head, tail))
-        },
-        x => x
-      )
+  def constantString(value: String): ConfigDescriptor[String, String, String] =
+    ConfigDescriptor.Source(ConfigSource.empty, ConstantString(value)) ?? s"constant string '$value'"
 
-  implicit def listt[A](implicit ev: DeriveConfigDescriptor[A]): DeriveConfigDescriptor[List[A]] =
-    (a, b) => legacyList(ev.getDescription(a, b))
+  def constant[T](label: String, value: T): ConfigDescriptor[String, String, T] =
+    constantString(label)(_ => value, (p: T) => Some(p).filter(_ == value).map(_ => label))
 
-  implicit def nonEmptyList[A](implicit ev: DeriveConfigDescriptor[A]): DeriveConfigDescriptor[::[A]] =
-    (a, b) =>
-      legacyList(ev.getDescription(a, b)).xmapEither(
-        list =>
-          list.headOption match {
-            case Some(value) => Right(::(value, list.tail))
-            case None =>
-              Left(
-                "The list is empty. Either provide a non empty list, and if not mark it as optional and choose to avoid it in the config"
-              )
-          },
-        ((nonEmpty: ::[A]) => Right(nonEmpty.toList))
-      )
+  protected def stringDesc: ConfigDescriptor[String, String, String]         = string
+  protected def booleanDesc: ConfigDescriptor[String, String, Boolean]       = boolean
+  protected def byteDesc: ConfigDescriptor[String, String, Byte]             = byte
+  protected def shortDesc: ConfigDescriptor[String, String, Short]           = short
+  protected def intDesc: ConfigDescriptor[String, String, Int]               = int
+  protected def longDesc: ConfigDescriptor[String, String, Long]             = long
+  protected def bigIntDesc: ConfigDescriptor[String, String, BigInt]         = bigInt
+  protected def floatDesc: ConfigDescriptor[String, String, Float]           = float
+  protected def doubleDesc: ConfigDescriptor[String, String, Double]         = double
+  protected def bigDecimalDesc: ConfigDescriptor[String, String, BigDecimal] = bigDecimal
+  protected def uriDesc: ConfigDescriptor[String, String, URI]               = uri
 
-  // This is equivalent to saying string("PATH").orElseEither(int("PATH")). During automatic derivations, we are unaware of alternate paths.
-  implicit def eith[A: DeriveConfigDescriptor, B: DeriveConfigDescriptor]: DeriveConfigDescriptor[Either[A, B]] =
-    new DeriveConfigDescriptor[Either[A, B]] {
-      override def getDescription(
-        path: Option[String],
-        parentClass: Option[String]
-      ): ConfigDescriptor[String, String, Either[A, B]] =
-        implicitly[DeriveConfigDescriptor[A]]
-          .getDescription(path, parentClass)
-          .orElseEither(implicitly[DeriveConfigDescriptor[B]].getDescription(path, parentClass))
+  implicit val implicitStringDesc: Typeclass[String]         = Descriptor(stringDesc)
+  implicit val implicitBooleanDesc: Typeclass[Boolean]       = Descriptor(booleanDesc)
+  implicit val implicitByteDesc: Typeclass[Byte]             = Descriptor(byteDesc)
+  implicit val implicitShortDesc: Typeclass[Short]           = Descriptor(shortDesc)
+  implicit val implicitIntDesc: Typeclass[Int]               = Descriptor(intDesc)
+  implicit val implicitLongDesc: Typeclass[Long]             = Descriptor(longDesc)
+  implicit val implicitBigIntDesc: Typeclass[BigInt]         = Descriptor(bigIntDesc)
+  implicit val implicitFloatDesc: Typeclass[Float]           = Descriptor(floatDesc)
+  implicit val implicitDoubleDesc: Typeclass[Double]         = Descriptor(doubleDesc)
+  implicit val implicitBigDecimalDesc: Typeclass[BigDecimal] = Descriptor(bigDecimalDesc)
+  implicit val implicitUriDesc: Typeclass[URI]               = Descriptor(uriDesc)
+
+  implicit def implicitListDesc[A: Typeclass]: Typeclass[List[A]] =
+    Descriptor(listDesc(implicitly[Typeclass[A]].desc))
+
+  implicit def implicitEitherDesc[A: Typeclass, B: Typeclass]: Typeclass[Either[A, B]] =
+    Descriptor(eitherDesc(implicitly[Typeclass[A]].desc, implicitly[Typeclass[B]].desc))
+
+  implicit def implicitOptionDesc[A: Typeclass]: Typeclass[Option[A]] =
+    Descriptor(optionDesc(implicitly[Typeclass[A]].desc))
+
+  protected def listDesc[A](desc: ConfigDescriptor[String, String, A]): ConfigDescriptor[String, String, List[A]] =
+    list(desc)
+
+  protected def eitherDesc[A, B](
+    left: ConfigDescriptor[String, String, A],
+    right: ConfigDescriptor[String, String, B]
+  ): ConfigDescriptor[String, String, Either[A, B]] =
+    left.orElseEither(right)
+
+  protected def optionDesc[A](desc: ConfigDescriptor[String, String, A]): ConfigDescriptor[String, String, Option[A]] =
+    desc.optional
+
+  case class Descriptor[T](desc: ConfigDescriptor[String, String, T], isObject: Boolean = false)
+
+  object Descriptor {
+    implicit def toConfigDescriptor[T](ev: Descriptor[T]): ConfigDescriptor[String, String, T] = ev.desc
+  }
+
+  type Typeclass[T] = Descriptor[T]
+
+  def toSnakeCase(name: String): String = {
+    def addToAcc(acc: List[String], current: List[Int]) = {
+      def currentWord = current.reverse.flatMap(i => Character.toChars(i)).mkString.toLowerCase
+      if (current.isEmpty) acc
+      else if (acc.isEmpty) currentWord :: Nil
+      else currentWord :: "_" :: acc
     }
 
-  type Typeclass[T] = DeriveConfigDescriptor[T]
+    @tailrec
+    def loop(chars: List[Int], acc: List[String], current: List[Int], beginning: Boolean): String =
+      chars match {
+        case Nil => addToAcc(acc, current).reverse.mkString
+        case head :: tail if beginning =>
+          loop(tail, acc, head :: current, Character.isUpperCase(head) || !Character.isLetter(head))
+        case head :: tail if Character.isUpperCase(head) =>
+          loop(tail, addToAcc(acc, current), head :: Nil, beginning = true)
+        case head :: tail =>
+          loop(tail, acc, head :: current, beginning = false)
+      }
 
-  def combine[T](caseClass: CaseClass[DeriveConfigDescriptor, T]): DeriveConfigDescriptor[T] =
-    new DeriveConfigDescriptor[T] {
-      def getDescription(path: Option[String], parentClass: Option[String]): ConfigDescriptor[String, String, T] = {
-        // A complex nested inductive resolution for parent paths (separately handled for case objects and classes) to get the ergonomics right in the hocon source.
-        val finalDesc =
-          if (caseClass.isObject) {
-            val config = parentClass match {
-              case Some(parentClass) => string(parentClass.toLowerCase())
+    loop(name.codePoints().iterator().asScala.map(x => x: Int).toList, Nil, Nil, beginning = true)
+  }
 
-              case None =>
-                string.xmapEither[String](
-                  _ =>
-                    Left(
-                      s"Cannot create the case-object ${caseClass.typeName.short} since it is not part of a coproduct (ie. extends sealed trait)"
-                    ),
-                  (_: String) =>
-                    Left(
-                      s"Cannot write the case-object ${caseClass.typeName.short} since it is not part of a coproduct (i.e, extends sealed trait)"
-                    )
-                )
+  def mapClassName(name: String): String
+
+  def mapFieldName(name: String): String
+
+  def wrapSealedTraitClasses: Boolean
+
+  def wrapSealedTraits: Boolean
+
+  final def wrapSealedTrait[T](
+    label: String,
+    desc: ConfigDescriptor[String, String, T]
+  ): ConfigDescriptor[String, String, T] =
+    if (wrapSealedTraits) nested(label)(desc)
+    else desc
+
+  final def prepareClassName(annotations: Seq[Any], name: String): String =
+    annotations.collectFirst { case d: name => d.name }.getOrElse(mapClassName(name))
+
+  final def prepareFieldName(annotations: Seq[Any], name: String): String =
+    annotations.collectFirst { case d: name => d.name }.getOrElse(mapFieldName(name))
+
+  final def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
+    val descriptions = caseClass.annotations.collect { case d: describe => d.describe }
+    val ccName       = prepareClassName(caseClass.annotations, caseClass.typeName.short)
+
+    val res =
+      if (caseClass.isObject) constant[T](ccName, caseClass.construct(_ => ???))
+      else
+        caseClass.parameters.toList match {
+          case Nil =>
+            constantString(ccName).xmap[T](
+              _ => caseClass.construct(_ => ???),
+              _ => ccName
+            )
+          case head :: tail =>
+            def makeDescriptor(param: Param[Typeclass, T]): ConfigDescriptor[String, String, Any] = {
+              val descriptions =
+                param.annotations
+                  .filter(_.isInstanceOf[describe])
+                  .map(_.asInstanceOf[describe].describe)
+
+              val paramName = prepareFieldName(param.annotations, param.label)
+
+              val raw = param.typeclass.desc
+
+              val withDefaults = param.default.fold(raw)(raw.default(_))
+
+              val described = descriptions.foldLeft(withDefaults)(_ ?? _)
+
+              nested(paramName)(described).asInstanceOf[ConfigDescriptor[String, String, Any]]
             }
-            config.xmapEither(
-              str =>
-                if (str == caseClass.typeName.short.toLowerCase()) Right(caseClass.rawConstruct(Seq.empty))
-                else
-                  Left("Not enough details in the config source to form the config using automatic derviation."),
-              (value: Any) => Right(value.toString.toLowerCase)
+
+            collectAll(makeDescriptor(head), tail.map(makeDescriptor): _*).xmap[T](
+              l => caseClass.rawConstruct(l),
+              t => caseClass.parameters.map(_.dereference(t)).toList
             )
-          } else {
-            val listOfConfigs: List[ConfigDescriptor[String, String, Any]] =
-              caseClass.parameters.toList.map { h =>
-                val rawDesc =
-                  h.typeclass.getDescription(Some(h.label), None)
+        }
 
-                val descriptions =
-                  h.annotations
-                    .filter(_.isInstanceOf[describe])
-                    .map(_.asInstanceOf[describe].describe)
+    Descriptor(descriptions.foldLeft(res)(_ ?? _), caseClass.isObject || caseClass.parameters.isEmpty)
+  }
 
-                val withDefault =
-                  h.default
-                    .map(r => rawDesc.default(r))
-                    .getOrElse(rawDesc)
+  final def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = {
+    val nameToLabel =
+      sealedTrait.subtypes
+        .map(tc => prepareClassName(tc.annotations, tc.typeName.short) -> tc.typeName.full)
+        .groupBy(_._1)
+        .toSeq
+        .flatMap {
+          case (label, Seq((_, fullName))) => (fullName -> label) :: Nil
+          case (label, seq) =>
+            seq.zipWithIndex.map { case ((_, fullName), idx) => fullName -> s"${label}_$idx" }
+        }
+        .toMap
 
-                val withDocs =
-                  updateConfigWithDocuments(descriptions, withDefault)
+    val desc =
+      sealedTrait.subtypes.map { subtype =>
+        val typeclass = subtype.typeclass
+        val desc =
+          if (typeclass.isObject || !wrapSealedTraitClasses) typeclass.desc
+          else nested(nameToLabel(subtype.typeName.full))(typeclass.desc)
 
-                val config = withDocs.xmap((r: h.PType) => r: Any, (r: Any) => r.asInstanceOf[h.PType])
-
-                parentClass.fold(config)(_ => nested(caseClass.typeName.short.toLowerCase())(config))
-
-              }
-
-            collectAll(::(listOfConfigs.head, listOfConfigs.tail))
-              .xmap[T](
-                cons => caseClass.rawConstruct(cons),
-                v => {
-                  val r = caseClass.parameters.map(_.dereference(v): Any).toList
-                  ::(r.head, r.tail)
-                }
-              )
-          }
-
-        val annotations = caseClass.annotations
-          .filter(_.isInstanceOf[zio.config.magnolia.describe])
-          .map(_.asInstanceOf[describe].describe)
-
-        val withParent =
-          if (caseClass.isObject) finalDesc
-          else
-            parentClass.fold(finalDesc)(parentClass => nested(parentClass.toLowerCase())(finalDesc))
-
-        updateConfigWithDocuments(
-          annotations,
-          path.fold(withParent)(nested(_)(withParent))
+        wrapSealedTrait(prepareClassName(sealedTrait.annotations, sealedTrait.typeName.short), desc).xmapEither[T](
+          st => Right(st),
+          t =>
+            subtype.cast
+              .andThen(Right(_))
+              .applyOrElse(t, (_: T) => Left(s"Expected ${subtype.typeName.full}, but got ${t.getClass.getName}"))
         )
-      }
-    }
+      }.reduce(_.orElse(_))
 
-  def dispatch[T](sealedTrait: SealedTrait[DeriveConfigDescriptor, T]): DeriveConfigDescriptor[T] =
-    new DeriveConfigDescriptor[T] {
-      def getDescription(paths: Option[String], parentClass: Option[String]): ConfigDescriptor[String, String, T] = {
-        val list         = sealedTrait.subtypes.toList
-        val head :: tail = ::(list.head, list.tail)
+    Descriptor(desc)
+  }
 
-        tail.foldRight[ConfigDescriptor[String, String, T]](
-          head.typeclass
-            .getDescription(paths, Some(sealedTrait.typeName.short.toLowerCase()))
-            .xmapEither(
-              (t: head.SType) => Right(t: T), { a: T =>
-                scala.util.Try(head.cast(a)) match {
-                  case Success(value) => Right(value)
-                  case Failure(value) => Left(s"Failure when trying to write: ${value.getMessage}")
-                }
-              }
-            )
-        )(
-          (e: Subtype[Typeclass, T], b: ConfigDescriptor[String, String, T]) =>
-            b.orElse(
-              e.typeclass
-                .getDescription(paths, Some(sealedTrait.typeName.short.toLowerCase()))
-                .xmapEither(
-                  (t: e.SType) => Right(t: T),
-                  (a: T) =>
-                    scala.util.Try(e.cast(a)) match {
-                      case Success(value) => Right(value)
-                      case Failure(value) => Left(s"Failure when trying to write: ${value.getMessage}")
-                    }
-                )
-            )
-        )
+  /**
+   * By default this method is not implicit to allow custom non-recursive derivation
+   * */
+  def descriptor[T: NeedsDerive]: Descriptor[T] = macro DescriptorMacro.gen[T]
 
-      }
-    }
+  /**
+   * Preventing derivation for List, Option and Either.
+   * */
+  sealed trait NeedsDerive[+T]
 
-  implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
+  object NeedsDerive extends NeedsDerive[Nothing] {
 
-  private[config] def updateConfigWithDocuments[K, V, A](
-    documents: Seq[String],
-    config: ConfigDescriptor[K, V, A]
-  ): ConfigDescriptor[K, V, A] =
-    documents.foldLeft(config)((cf, doc) => cf ?? doc)
+    implicit def needsDerive[R]: NeedsDerive[R] = NeedsDerive
+
+    implicit def needsDeriveAmbiguousList1: NeedsDerive[List[Nothing]] = NeedsDerive
+    implicit def needsDeriveAmbiguousList2: NeedsDerive[List[Nothing]] = NeedsDerive
+
+    implicit def needsDeriveAmbiguousOption1: NeedsDerive[Option[Nothing]] = NeedsDerive
+    implicit def needsDeriveAmbiguousOption2: NeedsDerive[Option[Nothing]] = NeedsDerive
+
+    implicit def needsDeriveAmbiguousEither1: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+    implicit def needsDeriveAmbiguousEither2: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+  }
 }

--- a/magnolia/src/main/scala/zio/config/magnolia/DescriptorMacro.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/DescriptorMacro.scala
@@ -1,0 +1,13 @@
+package zio.config.magnolia
+
+import magnolia.Magnolia
+
+import scala.reflect.macros.whitebox
+
+object DescriptorMacro {
+
+  def gen[T: c.WeakTypeTag](c: whitebox.Context)(ev: c.Tree): c.Tree = {
+    val _ = ev
+    Magnolia.gen[T](c)
+  }
+}

--- a/magnolia/src/main/scala/zio/config/magnolia/annotations.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/annotations.scala
@@ -3,3 +3,4 @@ package zio.config.magnolia
 import scala.annotation.StaticAnnotation
 
 final case class describe(describe: String) extends StaticAnnotation
+final case class name(name: String)         extends StaticAnnotation

--- a/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
+++ b/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
@@ -1,7 +1,7 @@
 package zio.config.magnolia
 
-import zio.config.ConfigDescriptor.{Describe, Nested}
-import zio.config.PropertyTree.{Leaf, Record, Sequence}
+import zio.config.ConfigDescriptor.{ Describe, Nested }
+import zio.config.PropertyTree.{ Leaf, Record, Sequence }
 import zio.config._
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.test.Assertion._
@@ -87,19 +87,14 @@ object DerivationTest extends DefaultRunnableSpec {
       case class A3(a: List[A2])
       case class A4(a: List[A3])
       case class A5(a: List[A4])
-      case class A6(a: List[A5])
-      case class A7(a: List[A6])
-      case class A8(a: List[A7])
-      case class A9(a: List[A8])
-      case class A10(a: List[A9])
 
       def loop(depth: Int): PropertyTree[String, String] =
         if (depth > 0) Record(Map("a" -> Sequence(List(loop(depth - 1)))))
         else Leaf("str")
 
-      val src = ConfigSource(loop(10), Set.empty)
+      val src = ConfigSource(loop(5), Set.empty)
 
-      val res = read(descriptor[A10] from src)
+      val res = read(descriptor[A5] from src)
 
       assert(res)(isRight(anything))
     },
@@ -111,25 +106,25 @@ object DerivationTest extends DefaultRunnableSpec {
         if (depth > 0) Record(Map("a" -> Sequence(List(loop(depth - 1)))))
         else Leaf("str")
 
-      val src = ConfigSource(loop(10), Set.empty)
+      val src = ConfigSource(loop(5), Set.empty)
 
-      val res = read(descriptor[A10] from src)
+      val res = read(descriptor[A5] from src)
 
       assert(res)(isRight(anything))
     },
     test("support nested lists non-recursive") {
-      import NonRecursiveDerivation.{Descriptor, descriptor}
+      import NonRecursiveDerivation.{ descriptor, Descriptor }
 
       case class A(a: List[String])
       implicit val cA: Descriptor[A] = descriptor[A]
       val _                          = cA
-      case class B(a: List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]]]]]]]]]]]])
+      case class B(a: List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]])
 
       def loop(depth: Int): PropertyTree[String, String] =
         if (depth > 0) Sequence(List(loop(depth - 1)))
         else Record(Map("a" -> Sequence(List(Leaf("s")))))
 
-      val src = ConfigSource(Record(Map("a" -> loop(20))), Set.empty)
+      val src = ConfigSource(Record(Map("a" -> loop(10))), Set.empty)
 
       val res = read(descriptor[B] from src)
 
@@ -137,13 +132,13 @@ object DerivationTest extends DefaultRunnableSpec {
     },
     test("support nested lists recursive") {
       case class A(a: List[String])
-      case class B(a: List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]]]]]]]]]]]])
+      case class B(a: List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]])
 
       def loop(depth: Int): PropertyTree[String, String] =
         if (depth > 0) Sequence(List(loop(depth - 1)))
         else Record(Map("a" -> Sequence(List(Leaf("s")))))
 
-      val src = ConfigSource(Record(Map("a" -> loop(2))), Set.empty)
+      val src = ConfigSource(Record(Map("a" -> loop(10))), Set.empty)
 
       val res = read(descriptor[B] from src)
 
@@ -153,7 +148,7 @@ object DerivationTest extends DefaultRunnableSpec {
 }
 
 object NonRecursiveListHelper {
-  import NonRecursiveDerivation.{Descriptor, descriptor}
+  import NonRecursiveDerivation.{ descriptor, Descriptor }
 
   case class A1(a: List[String])
   implicit val cA1: Descriptor[A1] = descriptor[A1]
@@ -164,15 +159,5 @@ object NonRecursiveListHelper {
   case class A4(a: List[A3])
   implicit val cA4: Descriptor[A4] = descriptor[A4]
   case class A5(a: List[A4])
-  implicit val cA5: Descriptor[A5] = descriptor[A5]
-  case class A6(a: List[A5])
-  implicit val cA6: Descriptor[A6] = descriptor[A6]
-  case class A7(a: List[A6])
-  implicit val cA7: Descriptor[A7] = descriptor[A7]
-  case class A8(a: List[A7])
-  implicit val cA8: Descriptor[A8] = descriptor[A8]
-  case class A9(a: List[A8])
-  implicit val cA9: Descriptor[A9] = descriptor[A9]
-  case class A10(a: List[A9])
 
 }

--- a/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
+++ b/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
@@ -1,0 +1,178 @@
+package zio.config.magnolia
+
+import zio.config.ConfigDescriptor.{Describe, Nested}
+import zio.config.PropertyTree.{Leaf, Record, Sequence}
+import zio.config._
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+import zio.test.Assertion._
+import zio.test._
+
+object DerivationTest extends DefaultRunnableSpec {
+  val spec = suite("DerivationTest")(
+    test("support describe annotation") {
+      @describe("class desc")
+      case class Cfg(@describe("field desc") fname: String)
+
+      def collectDescriptions[T](
+        desc: ConfigDescriptor[String, String, T],
+        path: Option[String]
+      ): List[(Option[String], String)] = desc match {
+        case ConfigDescriptor.Default(config, _) => collectDescriptions(config, path)
+        case Describe(config, message)           => (path, message) :: collectDescriptions(config, path)
+        case Nested(path, config)                => collectDescriptions(config, Some(path))
+        case ConfigDescriptor.Optional(config)   => collectDescriptions(config, path)
+        case ConfigDescriptor.OrElse(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case ConfigDescriptor.OrElseEither(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case ConfigDescriptor.Sequence(_, config) => collectDescriptions(config, path)
+        case ConfigDescriptor.Source(_, _)        => Nil
+        case ConfigDescriptor.Zip(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case ConfigDescriptor.XmapEither(config, _, _) => collectDescriptions(config, path)
+      }
+
+      assert(collectDescriptions(descriptor[Cfg], None))(
+        contains((None: Option[String]) -> "class desc") &&
+          contains(Some("fname")        -> "field desc")
+      )
+    },
+    test("support name annotation") {
+      @name("SealedTrait")
+      sealed trait St
+      @name("className")
+      case class Cfg(@name("otherName") fname: String) extends St
+
+      def collectPath[T](desc: ConfigDescriptor[String, String, T]): List[String] = desc match {
+        case ConfigDescriptor.Default(config, _)        => collectPath(config)
+        case Describe(config, _)                        => collectPath(config)
+        case Nested(path, config)                       => path :: collectPath(config)
+        case ConfigDescriptor.Optional(config)          => collectPath(config)
+        case ConfigDescriptor.OrElse(left, right)       => collectPath(left) ::: collectPath(right)
+        case ConfigDescriptor.OrElseEither(left, right) => collectPath(left) ::: collectPath(right)
+        case ConfigDescriptor.Sequence(_, config)       => collectPath(config)
+        case ConfigDescriptor.Source(_, _)              => Nil
+        case ConfigDescriptor.Zip(left, right)          => collectPath(left) ::: collectPath(right)
+        case ConfigDescriptor.XmapEither(config, _, _)  => collectPath(config)
+      }
+
+      assert(collectPath(descriptor[St]))(equalTo("SealedTrait" :: "className" :: "otherName" :: Nil))
+    },
+    test("support default value") {
+      @describe("class desc")
+      case class Cfg(fname: String = "defaultV")
+
+      def collectDefault[T](
+        desc: ConfigDescriptor[String, String, T],
+        path: Option[String]
+      ): List[(Option[String], Any)] = desc match {
+        case ConfigDescriptor.Default(config, v)  => (path -> v) :: collectDefault(config, path)
+        case Describe(config, _)                  => collectDefault(config, path)
+        case Nested(path, config)                 => collectDefault(config, Some(path))
+        case ConfigDescriptor.Optional(config)    => collectDefault(config, path)
+        case ConfigDescriptor.OrElse(left, right) => collectDefault(left, path) ::: collectDefault(right, path)
+        case ConfigDescriptor.OrElseEither(left, right) =>
+          collectDefault(left, path) ::: collectDefault(right, path)
+        case ConfigDescriptor.Sequence(_, config)      => collectDefault(config, path)
+        case ConfigDescriptor.Source(_, _)             => Nil
+        case ConfigDescriptor.Zip(left, right)         => collectDefault(left, path) ::: collectDefault(right, path)
+        case ConfigDescriptor.XmapEither(config, _, _) => collectDefault(config, path)
+      }
+
+      assert(collectDefault(descriptor[Cfg], None))(equalTo((Some("fname"), "defaultV") :: Nil))
+    },
+    test("support lists recursive") {
+      case class A1(a: List[String])
+      case class A2(a: List[A1])
+      case class A3(a: List[A2])
+      case class A4(a: List[A3])
+      case class A5(a: List[A4])
+      case class A6(a: List[A5])
+      case class A7(a: List[A6])
+      case class A8(a: List[A7])
+      case class A9(a: List[A8])
+      case class A10(a: List[A9])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Record(Map("a" -> Sequence(List(loop(depth - 1)))))
+        else Leaf("str")
+
+      val src = ConfigSource(loop(10), Set.empty)
+
+      val res = read(descriptor[A10] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support lists non-recursive") {
+      import NonRecursiveDerivation.descriptor
+      import NonRecursiveListHelper._
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Record(Map("a" -> Sequence(List(loop(depth - 1)))))
+        else Leaf("str")
+
+      val src = ConfigSource(loop(10), Set.empty)
+
+      val res = read(descriptor[A10] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support nested lists non-recursive") {
+      import NonRecursiveDerivation.{Descriptor, descriptor}
+
+      case class A(a: List[String])
+      implicit val cA: Descriptor[A] = descriptor[A]
+      val _                          = cA
+      case class B(a: List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]]]]]]]]]]]])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Sequence(List(loop(depth - 1)))
+        else Record(Map("a" -> Sequence(List(Leaf("s")))))
+
+      val src = ConfigSource(Record(Map("a" -> loop(20))), Set.empty)
+
+      val res = read(descriptor[B] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support nested lists recursive") {
+      case class A(a: List[String])
+      case class B(a: List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]]]]]]]]]]]])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Sequence(List(loop(depth - 1)))
+        else Record(Map("a" -> Sequence(List(Leaf("s")))))
+
+      val src = ConfigSource(Record(Map("a" -> loop(2))), Set.empty)
+
+      val res = read(descriptor[B] from src)
+
+      assert(res)(isRight(anything))
+    }
+  )
+}
+
+object NonRecursiveListHelper {
+  import NonRecursiveDerivation.{Descriptor, descriptor}
+
+  case class A1(a: List[String])
+  implicit val cA1: Descriptor[A1] = descriptor[A1]
+  case class A2(a: List[A1])
+  implicit val cA2: Descriptor[A2] = descriptor[A2]
+  case class A3(a: List[A2])
+  implicit val cA3: Descriptor[A3] = descriptor[A3]
+  case class A4(a: List[A3])
+  implicit val cA4: Descriptor[A4] = descriptor[A4]
+  case class A5(a: List[A4])
+  implicit val cA5: Descriptor[A5] = descriptor[A5]
+  case class A6(a: List[A5])
+  implicit val cA6: Descriptor[A6] = descriptor[A6]
+  case class A7(a: List[A6])
+  implicit val cA7: Descriptor[A7] = descriptor[A7]
+  case class A8(a: List[A7])
+  implicit val cA8: Descriptor[A8] = descriptor[A8]
+  case class A9(a: List[A8])
+  implicit val cA9: Descriptor[A9] = descriptor[A9]
+  case class A10(a: List[A9])
+
+}

--- a/magnolia/src/test/scala/zio/config/magnolia/OverrideDerivationTest.scala
+++ b/magnolia/src/test/scala/zio/config/magnolia/OverrideDerivationTest.scala
@@ -1,0 +1,103 @@
+package zio.config.magnolia
+
+import zio.config.PropertyTree.{ Leaf, Record, Sequence }
+import zio.config._
+import zio.test.Assertion._
+import zio.test._
+
+object OverrideDerivationTestEnv extends DeriveConfigDescriptor {
+  override def mapClassName(name: String): String = toSnakeCase(name) + "_suffix"
+  override def mapFieldName(name: String): String = "prefix_" + toSnakeCase(name)
+
+  val wrapSealedTraitClasses: Boolean = false
+  val wrapSealedTraits: Boolean       = false
+}
+
+object OverrideDerivationTest extends DefaultRunnableSpec {
+  val spec = suite("OverrideDerivationTest")(
+    test("simple config") {
+      import OverrideDerivationTestEnv._
+
+      case class Cfg(fieldName: String)
+
+      val res = write(descriptor[Cfg], Cfg("a"))
+
+      assert(res)(isRight(equalTo(Record(Map("prefix_field_name" -> Leaf("a")))))) &&
+      assert(res.map(ConfigSource(_, Set.empty)).flatMap(v => read(descriptor[Cfg] from v)))(
+        isRight(equalTo(Cfg("a")))
+      )
+    },
+    test("unwrapped sealed hierarchy") {
+      import OverrideDerivationTestEnv._
+
+      sealed trait Inner
+      case object Obj1Name                     extends Inner
+      case object OtherOBJECT                  extends Inner
+      case class ClassWithData(data: String)   extends Inner
+      case class ClassWithValue(value: String) extends Inner
+
+      case class Outer(list: List[Inner])
+
+      implicit val cInner: Typeclass[Inner] = descriptor[Inner]
+
+      val _ = cInner
+
+      val cfg = Outer(List(OtherOBJECT, Obj1Name, ClassWithValue("a"), ClassWithData("b")))
+
+      val res = write(OverrideDerivationTestEnv.descriptor[Outer], cfg)
+
+      val expected = Record(
+        Map(
+          "prefix_list" -> Sequence(
+            List(
+              Leaf("other_object_suffix"),
+              Leaf("obj1_name_suffix"),
+              Record(Map("prefix_value" -> Leaf("a"))),
+              Record(Map("prefix_data"  -> Leaf("b")))
+            )
+          )
+        )
+      )
+
+      assert(res)(isRight(equalTo(expected))) &&
+      assert(
+        res.map(ConfigSource(_, Set.empty)).flatMap(v => read(descriptor[Outer] from v))
+      )(
+        isRight(equalTo(cfg))
+      )
+    },
+    test("wrapped sealed hierarchy") {
+      import DeriveConfigDescriptor._
+
+      sealed trait Inner
+      case object Obj1Name                     extends Inner
+      case object OtherOBJECT                  extends Inner
+      case class ClassWithData(data: String)   extends Inner
+      case class ClassWithValue(value: String) extends Inner
+
+      case class Outer(list: List[Inner])
+
+      val cfg = Outer(List(OtherOBJECT, Obj1Name, ClassWithValue("a"), ClassWithData("b")))
+
+      val res = write(descriptor[Outer], cfg)
+
+      val expected = Record(
+        Map(
+          "list" -> Sequence(
+            List(
+              Record(Map("inner" -> Leaf("other_object"))),
+              Record(Map("inner" -> Leaf("obj1_name"))),
+              Record(Map("inner" -> Record(Map("class_with_value" -> Record(Map("value" -> Leaf("a"))))))),
+              Record(Map("inner" -> Record(Map("class_with_data" -> Record(Map("data" -> Leaf("b")))))))
+            )
+          )
+        )
+      )
+
+      assert(res)(isRight(equalTo(expected))) &&
+      assert(res.map(ConfigSource(_, Set.empty)).flatMap(v => read(DeriveConfigDescriptor.descriptor[Outer] from v)))(
+        isRight(equalTo(cfg))
+      )
+    }
+  )
+}

--- a/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
+++ b/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
@@ -46,7 +46,7 @@ object RefinedReadWriteRoundtripTestUtils {
     ldap: Refined[String, NonEmpty],
     port: Refined[Int, GreaterEqual[W.`1024`.T]],
     dburl: Option[Refined[String, NonEmpty]], // Even if optional, if the predicate fails for a value that exist, we should fail it and report !
-    longs: Refined[::[Long], Size[Greater[W.`2`.T]]]
+    longs: Refined[List[Long], Size[Greater[W.`2`.T]]]
   )
 
   def longList(n: Int): ::[ConfigDescriptor[String, String, Long]] = {
@@ -57,8 +57,10 @@ object RefinedReadWriteRoundtripTestUtils {
     ::(list.head, list.tail)
   }
 
-  def longs(n: Int): ConfigDescriptor[String, String, ::[Long]] =
-    ConfigDescriptor.collectAll[String, String, Long](longList(n))
+  def longs(n: Int): ConfigDescriptor[String, String, List[Long]] = {
+    val ll = longList(n)
+    ConfigDescriptor.collectAll[String, String, Long](ll.head, ll.tail: _*)
+  }
 
   def prodConfig(n: Int): ConfigDescriptor[String, String, RefinedProd] =
     (

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -1,129 +1,128 @@
 package zio.config.typesafe
 
 import zio.config.PropertyTree.{ Leaf, Record, Sequence }
-import zio.config.{ BaseSpec, _ }
-import zio.config.magnolia.DeriveConfigDescriptor._
+import zio.config._
+import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.typesafe.TypesafeConfigSpecUtils._
 import zio.test.Assertion._
 import zio.test._
 
-object TypesafeConfigSpec
-    extends BaseSpec(
-      suite("TypesafeConfig")(
-        test("Read empty list") {
-          val res =
-            TypeSafeConfigSource.fromHoconString(
-              """
-                |a {
-                |  b = "s"
-                |  c = []
-                |}
-                |""".stripMargin
-            )
+object TypesafeConfigSpec extends DefaultRunnableSpec {
+  val spec = suite("TypesafeConfig")(
+    test("Read empty list") {
+      val res =
+        TypeSafeConfigSource.fromHoconString(
+          """
+            |a {
+            |  b = "s"
+            |  c = []
+            |}
+            |""".stripMargin
+        )
 
-          val expected = Record(Map("a" -> Record(Map("b" -> Leaf("s"), "c" -> Sequence(Nil)))))
+      val expected = Record(Map("a" -> Record(Map("b" -> Leaf("s"), "c" -> Sequence(Nil)))))
 
-          assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
-        },
-        test("Read mixed list") {
-          val res =
-            TypeSafeConfigSource.fromHoconString(
-              """
-                |list = [
-                |  "a",
-                |  {b = "c"}
-                |]
-                |""".stripMargin
-            )
+      assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
+    },
+    test("Read mixed list") {
+      val res =
+        TypeSafeConfigSource.fromHoconString(
+          """
+            |list = [
+            |  "a",
+            |  {b = "c"}
+            |]
+            |""".stripMargin
+        )
 
-          val expected = Record(Map("list" -> Sequence(List(Leaf("a"), Record(Map("b" -> Leaf("c")))))))
+      val expected = Record(Map("list" -> Sequence(List(Leaf("a"), Record(Map("b" -> Leaf("c")))))))
 
-          assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
-        },
-        testM(
-          "Read a complex hocon structure successfully"
-        ) {
-          //Fixme
-          check(Gen.const(configString)) {
-            input =>
-              {
-                val config =
-                  TypeSafeConfigSource.fromHoconString(input) match {
-                    case Left(value) => Left(value)
-                    case Right(value) =>
-                      read(descriptor[A] from value) match {
-                        case Left(value)  => Left(value.toString)
-                        case Right(value) => Right(value)
-                      }
+      assert(res.map(_.getConfigValue(List.empty)))(isRight(equalTo(expected)))
+    },
+    testM(
+      "Read a complex hocon structure successfully"
+    ) {
+      //Fixme
+      check(Gen.const(configString)) {
+        input =>
+          {
+            val config =
+              TypeSafeConfigSource.fromHoconString(input) match {
+                case Left(value) => Left(value)
+                case Right(value) =>
+                  read(descriptor[A] from value) match {
+                    case Left(value)  => Left(value.toString)
+                    case Right(value) => Right(value)
                   }
+              }
 
-                assert(config)(
-                  equalTo(
-                    Right(
-                      A(
+            assert(config)(
+              isRight(
+                equalTo(
+                  A(
+                    List(
+                      B(
                         List(
-                          B(
+                          C(
                             List(
-                              C(
-                                List(
-                                  D(NonEmptyList(1, 1, 1), List("a", "b", "c"), None, Nil),
-                                  D(NonEmptyList(12, 12), List("d"), Some(Nil), List(Nil)),
-                                  D(NonEmptyList(14, 14), Nil, Some(List("a")), List(List(Nil))),
-                                  D(NonEmptyList(15, 15), List("f", "g"), Some(List("", "")), List(List(List("x"))))
-                                ),
-                                Nil
-                              )
+                              D(List(1, 1, 1), List("a", "b", "c"), None, Nil),
+                              D(List(12, 12), List("d"), Some(Nil), List(Nil)),
+                              D(List(14, 14), Nil, Some(List("a")), List(List(Nil))),
+                              D(List(15, 15), List("f", "g"), Some(List("", "")), List(List(List("x"))))
                             ),
-                            "some_name",
-                            List("aa"),
-                            Nil
-                          ),
-                          B(
-                            List(
-                              C(
-                                List(
-                                  D(List(21, 21), List("af"), None, Nil),
-                                  D(List(22, 22), List("sa", "l"), None, Nil),
-                                  D(List(23, 23, 23), List("af", "l"), Some(Nil), List(Nil)),
-                                  D(List(24, 24, 24), List("l"), Some(Nil), List(List(Nil)))
-                                ),
-                                Nil
-                              )
-                            ),
-                            "some_name",
-                            List("a", "b", "c", "d", "e"),
-                            Nil
-                          ),
-                          B(
-                            List(
-                              C(
-                                List(
-                                  D(List(31, 31), List("bb"), None, Nil),
-                                  D(List(32, 32), List("x"), None, Nil),
-                                  D(List(33, 33, 33), List("xx"), None, Nil),
-                                  D(Nil, List("b"), None, Nil),
-                                  D(List(37), List("e", "f", "g", "h", "i"), None, Nil)
-                                ),
-                                Nil
-                              )
-                            ),
-                            "some_name",
-                            List("a"),
                             Nil
                           )
                         ),
-                        X(Y("k")),
-                        W(X(Y("k"))),
+                        "some_name",
+                        List("aa"),
+                        Nil
+                      ),
+                      B(
+                        List(
+                          C(
+                            List(
+                              D(List(21, 21), List("af"), None, Nil),
+                              D(List(22, 22), List("sa", "l"), None, Nil),
+                              D(List(23, 23, 23), List("af", "l"), Some(Nil), List(Nil)),
+                              D(List(24, 24, 24), List("l"), Some(Nil), List(List(Nil)))
+                            ),
+                            Nil
+                          )
+                        ),
+                        "some_name",
+                        List("a", "b", "c", "d", "e"),
+                        Nil
+                      ),
+                      B(
+                        List(
+                          C(
+                            List(
+                              D(List(31, 31), List("bb"), None, Nil),
+                              D(List(32, 32), List("x"), None, Nil),
+                              D(List(33, 33, 33), List("xx"), None, Nil),
+                              D(Nil, List("b"), None, Nil),
+                              D(List(37), List("e", "f", "g", "h", "i"), None, Nil)
+                            ),
+                            Nil
+                          )
+                        ),
+                        "some_name",
+                        List("a"),
                         Nil
                       )
-                    )
+                    ),
+                    X(Y("k")),
+                    W(X(Y("k"))),
+                    Nil
                   )
                 )
-              }
+              )
+            )
           }
-        }
-      )
-    )
+      }
+    }
+  )
+}
 
 object TypesafeConfigSpecUtils {
 


### PR DESCRIPTION
Fix derivation for `magnolia-0.14.1`. It seems like new `magnolia` performs recursive derivation only if it was originally called on implicit method.

There is also a bug in `magnolia`: in recursive derivation external implicit search depth is limited, so it can get external typeclass for `List[A]`, but not for `List[List[A]]`. It leads to infinite recursion in runtime. So there is a trick used to prevent derivation for `List`, `Option` and `Either`.

Derivation is now configurable. One can extend `DeriveConfigDescriptor` and make it non-recursive, more strict or relaxed, configure ADT handling or change name mapping.

`::` type is not dotty-compatible, so I'm gettign rid of it if I see it.