### PR TITLE
Add narrow syntax helper to zoom into configs

### DIFF
--- a/core/src/main/scala/zio/config/syntax/package.scala
+++ b/core/src/main/scala/zio/config/syntax/package.scala
@@ -1,0 +1,11 @@
+package zio.config
+
+import zio.{ Has, Tagged, ZLayer }
+
+package object syntax {
+
+  final implicit class ZIOConfigNarrowOps[R, E, A](val self: ZLayer[R, E, Has[A]]) extends AnyVal {
+    def narrow[B: Tagged](f: A => B)(implicit T: Tagged[A]): ZLayer[R, E, Has[B]] =
+      self.map(a => Has(f(a.get)))
+  }
+}

--- a/core/src/test/scala/zio/config/SyntaxTest.scala
+++ b/core/src/test/scala/zio/config/SyntaxTest.scala
@@ -1,0 +1,19 @@
+package zio.config
+
+import zio.{ Has, ZIO, ZLayer }
+import zio.config.syntax._
+import zio.test.Assertion._
+import zio.test._
+
+object SyntaxTest
+    extends BaseSpec(
+      suite("SyntaxTest")(
+        testM("config.narrow") {
+          case class Cfg(a: String, b: Int)
+          val cfg = ZLayer.succeed(Cfg("a", 1))
+          val a   = ZIO.access[Has[String]](_.get)
+
+          assertM(a.provideLayer(cfg.narrow(_.a)))(equalTo("a"))
+        }
+      )
+    )


### PR DESCRIPTION
### Motivation

There's no easy way to grab a subset of config to pass it down to a service, that needs only that subset. It is a drag in real-world apps, making separation of concerns painful. [Detailed case on discord](https://discordapp.com/channels/629491597070827530/633028431000502273/689138668392415280).

### Proposal

This PR adds a simple syntax extension to `ZLayer`: with it you can create layers for nested configurations right in place, like this:

```scala
import zio.config.syntax._ // extension is here

val cfg = TypesafeConfig.fromHoconString(str, AppConfig.description)
cfg.narrow(_.api) >>> endpoint
cfg.narrow(_.db) >>> repository
```

It uses `ZLayer` map which means no additional side-effects are executed in these child layers, as demonstrated by [this example](https://scastie.scala-lang.org/svgR5W67Q2CCOgIRA2WU1Q).

**P. S.** Went with pretty simple `syntax` package to put the extension to. Open to suggestions to improve it.