### PR TITLE
Fix BuildInfo package

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -34,7 +34,7 @@ object BuildHelper {
 
   val buildInfoSettings = Seq(
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
-    buildInfoPackage := "zio",
+    buildInfoPackage := "zio.config",
     buildInfoObject := "BuildInfo"
   )
 


### PR DESCRIPTION
This PR fixes a package for generated `BuildInfo`. Currently it is same as in core `zio` library - so this causes duplication errors when building assembly.  