### PR TITLE
Fix typo in name of an object

### DIFF
--- a/docs/automatic/index.md
+++ b/docs/automatic/index.md
@@ -15,7 +15,7 @@ Take a look at the magnolia examples in `zio-config`
 
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 
 object CoproductSealedTraitExample extends App {
 
@@ -29,7 +29,7 @@ object CoproductSealedTraitExample extends App {
   case class Region(suburb: String, city: String)
 
   val aHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = a
@@ -38,7 +38,7 @@ object CoproductSealedTraitExample extends App {
       .loadOrThrow
 
   val bHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = b
@@ -47,7 +47,7 @@ object CoproductSealedTraitExample extends App {
       .loadOrThrow
 
   val cHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = c
@@ -56,7 +56,7 @@ object CoproductSealedTraitExample extends App {
       .loadOrThrow
 
   val dHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x {
@@ -90,7 +90,7 @@ object CoproductSealedTraitExample extends App {
      def loadOrThrow: B = either match {
         case Left(_) => throw new Exception()
         case Right(v) => v
-      
+
      }
   }
 }

--- a/docs/configdescriptor/index.md
+++ b/docs/configdescriptor/index.md
@@ -3,7 +3,7 @@ id: configdescriptor_index
 title:  "Creation of ConfigDescriptor"
 ---
 
-Config Descriptor is the core of your configuration management. You can write a description by hand, 
+Config Descriptor is the core of your configuration management. You can write a description by hand,
 or rely on zio-config-magnolia that can automatically generate the description for you, based on the case classes (pr sealed traits)
 that represents your config.
 
@@ -82,7 +82,7 @@ systemSource.flatMap(source => ZIO.fromEither(read(myConfig from source)))
 
 ```
 
-You can run this to [completion](https://zio.dev/docs/getting_started.html#main) as in any zio application. 
+You can run this to [completion](https://zio.dev/docs/getting_started.html#main) as in any zio application.
 
 We will not be discussing about running with ZIO again, as it is just the same regardless of what the description is.
 We will discuss only about how to describe your configuration for the rest of this page.
@@ -118,19 +118,19 @@ etc
 
 ## Optional Types
 
-Say, dburl is an optional type, then it is as simple as 
+Say, dburl is an optional type, then it is as simple as
 
 ```scala mdoc:silent
 string("DB_URL").optional
 ```
 
-That is, 
+That is,
 
 ```scala mdoc:silent
 case class MyConfigWithOptionalUrl(ldap: String, port: Port, dburl: Option[String])
 
 val myConfigOptional =
-  (string("LDAP") |@| int("PORT")(Port.apply, Port.unapply) |@| 
+  (string("LDAP") |@| int("PORT")(Port.apply, Port.unapply) |@|
     string("DB_URL").optional)(MyConfigWithOptionalUrl.apply, MyConfigWithOptionalUrl.unapply)
 
 ```
@@ -139,10 +139,10 @@ val myConfigOptional =
 Sometimes, we don't need an optional value and instead happy providing a default value.
 
 ```scala mdoc:silent
- 
- val defaultConfig = 
+
+ val defaultConfig =
   string("USERNAME").default("ROOT")
- 
+
 ```
 
  That is,
@@ -165,7 +165,7 @@ myConfigDefault.default(MyConfigWithDefaultUserName("test", 80))
 ## New types
 We love `Port` instead of `Int` that represents a db port.
 
-In this scenario, you could do 
+In this scenario, you could do
 
 ```scala mdoc:silent
 
@@ -180,7 +180,7 @@ where port is;
 
 ```
 
-That is, 
+That is,
 
 ```scala mdoc:silent
 
@@ -204,26 +204,26 @@ zio-config do support this scenario. This can happen in complex applications.
 val configDesc = for {
  source1 <- ConfigSource.fromSystemProperties
  source2 <- ConfigSource.fromSystemEnv
- desc = 
+ desc =
    (string("LDAP").from(source1.orElse(source2)) |@| int("PORT")(Port.apply, Port.unapply).from(source1) |@|
     string("DB_URL").optional.from(source2))(MyConfigWithOptionalUrl.apply, MyConfigWithOptionalUrl.unapply)
 } yield desc
 
 
-configDesc.flatMap(desc => ZIO.fromEither(read(desc)))    
+configDesc.flatMap(desc => ZIO.fromEither(read(desc)))
 
 // we can also separately add new config
-configDesc.flatMap(desc => ZIO.fromEither(read(desc from ConfigSource.fromMap(Map.empty))))    
+configDesc.flatMap(desc => ZIO.fromEither(read(desc from ConfigSource.fromMap(Map.empty))))
 
 // In this case, `ConfigSource.fromMap` will also be tried along with the sources that are already given.
 
 ```
 
-We can reset the sources for the config using  
+We can reset the sources for the config using
 
 ```scala mdoc:silent
 
-configDesc.map(desc => desc.unsourced)    
+configDesc.map(desc => desc.unsourced)
 
 ```
 
@@ -235,8 +235,8 @@ from a constant map for all of it.
 val testConfig =
   configDesc
     .map(
-      desc => 
-        desc.unsourced from ConfigSource.fromMap(Map("LDAP" -> "x", "DB_URL" -> "y",  "PORT" -> "1235")))   
+      desc =>
+        desc.unsourced from ConfigSource.fromMap(Map("LDAP" -> "x", "DB_URL" -> "y",  "PORT" -> "1235")))
 
 ```
 
@@ -298,7 +298,7 @@ string("TOKEN") orElse string("token")
 Example:
 
 ```scala mdoc:silent
-val configOrElse = 
+val configOrElse =
   (string("TOKEN").orElse(string("token_x")) |@| int("CODE")) (Prod.apply, Prod.unapply)
 
 ```
@@ -308,13 +308,13 @@ It tries to fetch the value corresponding to "TOKEN", and if it fails, it tries 
 We can also use `<>` combinator.
 
 ```scala mdoc:silent
-string("TOKEN") <> string("token") <> string("TOKEN_INFO") 
+string("TOKEN") <> string("token") <> string("TOKEN_INFO")
 ```
 
 ## Composing multiple configurations
 
 This is more of a real life scenario, where you can different micro configurations for readability and maintainability.
- 
+
 ```scala mdoc:silent
   case class Database(url: String, port: Int)
   case class AwsConfig(c1: Database, c3: String)
@@ -327,7 +327,7 @@ This is more of a real life scenario, where you can different micro configuratio
 
 ```
 
-## Nesting 
+## Nesting
 
 In addition to the primitive types, zio-config provides a combinator for nesting a configuration within another.
 
@@ -351,7 +351,7 @@ any other configuration parsing libraries that deal with file formats such as HO
       "south.port"       -> "8111",
       "appName"          -> "myApp"
     )
-    
+
   Config.fromMap(constantMap, appConfig)
 ```
 
@@ -361,11 +361,11 @@ Note that, you can write this back as well. This is discussed in write section
 
 
 ```scala mdoc:silent
- def database(i: Int) = 
+ def database(i: Int) =
    (string(s"${i}_URL") |@| int(s"${i}_PORT"))(Database, Database.unapply)
 
  val list: ConfigDescriptor[String, String, List[Database]] =
-   collectAll(database(0), (1 to 10).map(database): _*) 
+   collectAll(database(0), (1 to 10).map(database): _*)
 
 ```
 Running this to ZIO will result in non empty list of database
@@ -377,17 +377,17 @@ NOTE: `collectAll` is a synonym for `sequence`.
 ```scala
 
   final case class PgmConfig(a: String, b: List[String])
-  
-  val configWithList = 
+
+  val configWithList =
     (string("xyz") |@| list("regions")(string))(PgmConfig.apply, PgmConfig.unapply)
 
-  
+
   Config.fromEnv(configWithList, valueDelimiter = Some(","))
-  // or read(configWithList from ConfigSource.fromEnv(valueDelimiter = Some(",")))  
+  // or read(configWithList from ConfigSource.fromEnv(valueDelimiter = Some(",")))
 
 ```
 
-List is probably better represented in HOCON files. 
+List is probably better represented in HOCON files.
 zio-config-typesafe enables you to depend on HOCON files to manage your configuration.
 
 Given;
@@ -405,7 +405,7 @@ val listHocon = """
          accountId: chris
       }
     ]
-    database { 
+    database {
         port : 100
         url  : postgres
     }
@@ -415,7 +415,7 @@ val listHocon = """
 
 ```scala
 
-import zio.config.typesafe.TypeSafeConfigSource._
+import zio.config.typesafe.TypesafeConfigSource._
 import zio.config.magnolia.DeriveConfigDescriptor._
 
   // A nested example with type safe config, and usage of magnolia

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -45,7 +45,7 @@ val mapSource =
       "PORT" -> "1222",
       "DB_URL" -> "postgres"
     )
-  )  
+  )
 
 val io = read(myConfig from mapSource)
 // Running io (which is a zio) to completion yields  MyConfig(xyz, 1222, postgres)
@@ -79,7 +79,7 @@ val multiMapSource =
       "DB_URL" -> ::("postgres",  Nil)
     )
   )
-  
+
 read(myConfig from multiMapSource)
 // Running this to completion yields ListConfig(xyz, List(1222, 2221), postgres)
 
@@ -102,12 +102,12 @@ val sysEnvSource =
   ConfigSource.fromSystemEnv
 
 // If you want to support list of values, then you should be giving a valueDelimiter
-val sysEnvSourceSupportingList = 
-  ConfigSource.fromSystemEnv(keyDelimiter = None, valueDelimiter = Some(',')) 
+val sysEnvSourceSupportingList =
+  ConfigSource.fromSystemEnv(keyDelimiter = None, valueDelimiter = Some(','))
 
 // If you want to consider system-env as a nested config, provide keyDelimiter. Refer to API docs
 // Example, Given KAFKA_SERVERS = "servers1, server2"
-  ConfigSource.fromSystemEnv(keyDelimiter = Some('_'), valueDelimiter = Some(',')) 
+  ConfigSource.fromSystemEnv(keyDelimiter = Some('_'), valueDelimiter = Some(','))
 
 
 ```
@@ -115,7 +115,7 @@ val sysEnvSourceSupportingList =
 
 Provide keyDelimiter if you need to consider flattened config as a nested config.
 Provide valueDelimiter if you need any value to be a list
-   
+
 Example:
 
 ```
@@ -126,7 +126,7 @@ Given:
   keyDelimiter   = Some('.')
   valueDelimiter = Some(',')
 }}}
-   
+
 ```
 then, the below config will work
 
@@ -135,8 +135,8 @@ nested("KAFKA")(string("SERVER") |@| string("FLAG"))(KafkaConfig.apply, KafkaCon
 ```
 
 
-Give valueDelimiter =  `,` 
-and environment with `PORT=1222,2221`; then reading config yields 
+Give valueDelimiter =  `,`
+and environment with `PORT=1222,2221`; then reading config yields
 `ListConfig(xyz, List(1222, 2221), postgres)`
 
 ## System Properties
@@ -149,17 +149,17 @@ val sysPropertiesSource =
   ConfigSource.fromSystemProperties
 
 // If you want to support list of values, then you should be giving a valueDelimiter
-val sysPropertiesSourceWithList = 
-  ConfigSource.fromSystemProperties(None, valueDelimiter = Some(',')) 
+val sysPropertiesSourceWithList =
+  ConfigSource.fromSystemProperties(None, valueDelimiter = Some(','))
 
 // If you want to consider system-properties as a nested config, provide keyDelimiter. Refer to API doc
 // Example, Given KAFKA.SERVERS = "servers1, server2"
-  ConfigSource.fromSystemProperties(keyDelimiter = Some('.'), valueDelimiter = Some(',')) 
+  ConfigSource.fromSystemProperties(keyDelimiter = Some('.'), valueDelimiter = Some(','))
 
 
 ```
-Give valueDelimiter =  `,` 
-and environemnt with `PORT=1222,2221`; then reading config yields 
+Give valueDelimiter =  `,`
+and environemnt with `PORT=1222,2221`; then reading config yields
 `ListConfig(xyz, List(1222, 2221), postgres)`
 
 
@@ -172,7 +172,7 @@ val javaProperties: java.util.Properties = new java.util.Properties() // Ideally
 val javaPropertiesSource =
   ConfigSource.fromProperties(javaProperties)
 
-read(myConfig from javaPropertiesSource)  
+read(myConfig from javaPropertiesSource)
 
 // If you want to support list of values, then you should be giving a valueDelimiter
 val javaPropertiesSourceWithList =
@@ -183,9 +183,9 @@ val javaPropertiesSourceWithList =
 
 ```scala mdoc:silent
 
-Config.fromPropertiesFile("filepath", myConfig) 
+Config.fromPropertiesFile("filepath", myConfig)
 
-// yielding Config[MyConfig] which you provide to 
+// yielding Config[MyConfig] which you provide to
 // functions with zio environment as Config[MyConfig]
 
 ```
@@ -193,13 +193,13 @@ Config.fromPropertiesFile("filepath", myConfig)
 ## HOCON String Source
 
 To enable HOCON source, you have to bring in `zio-config-typesafe` module.
-There are many examples in examples module in zio-config. 
+There are many examples in examples module in zio-config.
 
 Here is an quick example
 
 ```scala mdoc:silent
 
-import zio.config.typesafe._, TypeSafeConfigSource._
+import zio.config.typesafe._, TypesafeConfigSource._
 import zio.config.magnolia.DeriveConfigDescriptor._
 
 ```
@@ -211,20 +211,20 @@ case class SimpleConfig(port: Int, url: String, region: Option[String])
 val automaticDescription = descriptor[SimpleConfig]
 
 val hoconSource =
-  TypeSafeConfigSource.fromHoconString(
+  TypesafeConfigSource.fromHoconString(
       """
       {
         port : 123
         url  : bla
         region: useast
       }
-      
+
       """
     )
-  
+
 
 val anotherHoconSource =
-  TypeSafeConfigSource.fromHoconString(
+  TypesafeConfigSource.fromHoconString(
       """
         port=123
         url=bla
@@ -235,7 +235,7 @@ val anotherHoconSource =
 hoconSource match {
   case Left(value) => Left(value)
   case Right(source) => read(automaticDescription from source)
-}  
+}
 
 // yielding Right(SimpleConfig(123,bla,Some(useast)))
 
@@ -286,9 +286,9 @@ val jsonString =
      "url"  : "bla"
      "region": "useast"
    }
-   
+
    """
-    
+
 TypesafeConfig.fromHoconString(jsonString, automaticDescription)
 
 

--- a/examples/src/main/scala/zio/config/examples/magnolia/Simple.scala
+++ b/examples/src/main/scala/zio/config/examples/magnolia/Simple.scala
@@ -3,7 +3,7 @@ package zio.config.examples.magnolia
 import zio.config._
 import zio.config.examples.typesafe.EitherImpureOps
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 
 sealed trait X
 case object A                                 extends X
@@ -46,7 +46,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(descriptor[CfgCfg] from TypeSafeConfigSource.fromHoconString(s1).loadOrThrow) == Right(
+    read(descriptor[CfgCfg] from TypesafeConfigSource.fromHoconString(s1).loadOrThrow) == Right(
       CfgCfg(Cfg(C("b", G("hi"))), 1, "l")
     )
   )
@@ -59,7 +59,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s2).loadOrThrow) == Right(Cfg(A))
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s2).loadOrThrow) == Right(Cfg(A))
   )
 
   val s3 =
@@ -70,7 +70,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s3).loadOrThrow) == Right(Cfg(B))
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s3).loadOrThrow) == Right(Cfg(B))
   )
 
   val s4 =
@@ -91,7 +91,7 @@ object Cfg extends App with EitherImpureOps {
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s4).loadOrThrow) == Right(Cfg(D(Z("1"))))
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s4).loadOrThrow) == Right(Cfg(D(Z("1"))))
   )
 
   val s5 =
@@ -102,13 +102,13 @@ object Cfg extends App with EitherImpureOps {
       |      a = 1
       |      b = 2
       |    }
-      |  
+      |
       |  }
       |}
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s5).loadOrThrow) == Right(Cfg(E("1", 2)))
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s5).loadOrThrow) == Right(Cfg(E("1", 2)))
   )
 
   val s6 =
@@ -125,13 +125,13 @@ object Cfg extends App with EitherImpureOps {
       |        }
       |      }
       |    }
-      |  
+      |
       |  }
       |}
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s6).loadOrThrow) == Right(
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s6).loadOrThrow) == Right(
       Cfg(F("1", None, Z("2")))
     )
   )
@@ -151,13 +151,13 @@ object Cfg extends App with EitherImpureOps {
       |        }
       |      }
       |    }
-      |  
+      |
       |  }
       |}
       |""".stripMargin
 
   assert(
-    read(descriptor[Cfg] from TypeSafeConfigSource.fromHoconString(s7).loadOrThrow) == Right(
+    read(descriptor[Cfg] from TypesafeConfigSource.fromHoconString(s7).loadOrThrow) == Right(
       Cfg(F("1", Some(2), Z("2")))
     )
   )

--- a/examples/src/main/scala/zio/config/examples/typesafe/CoproductSealedTraitExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/CoproductSealedTraitExample.scala
@@ -2,7 +2,7 @@ package zio.config.examples.typesafe
 
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 
 object CoproductSealedTraitExample extends App with EitherImpureOps {
 
@@ -16,7 +16,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
   case class Region(suburb: String, city: String)
 
   val aHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = a
@@ -25,7 +25,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
       .loadOrThrow
 
   val bHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = b
@@ -34,7 +34,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
       .loadOrThrow
 
   val cHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x = c
@@ -43,7 +43,7 @@ object CoproductSealedTraitExample extends App with EitherImpureOps {
       .loadOrThrow
 
   val dHoconSource =
-    TypeSafeConfigSource
+    TypesafeConfigSource
       .fromHoconString(
         s"""
            |x {

--- a/examples/src/main/scala/zio/config/examples/typesafe/ListExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/ListExample.scala
@@ -3,7 +3,7 @@ package zio.config.examples.typesafe
 import com.typesafe.config.ConfigRenderOptions
 import zio.config._
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 
 object ListExample extends App with EitherImpureOps {
   val configString =
@@ -43,7 +43,7 @@ object ListExample extends App with EitherImpureOps {
       |      }
       |    ]
       |  }
-      |  
+      |
       |  {
       |   table          : some_name
       |   columns        : [a, b, c, d, e]
@@ -147,7 +147,7 @@ object ListExample extends App with EitherImpureOps {
 
   // Since we already have a string with us, we don't need Config Service (or ZIO)
   val source =
-    TypeSafeConfigSource.fromHoconString(configString).loadOrThrow // Don't use loadOrThrow. This is only for example
+    TypesafeConfigSource.fromHoconString(configString).loadOrThrow // Don't use loadOrThrow. This is only for example
 
   val zioConfigResult =
     read(descriptor[A] from source)
@@ -232,7 +232,7 @@ object ListExample extends App with EitherImpureOps {
     write(descriptor[A], expectedResult).loadOrThrow.toHocon
       .render(ConfigRenderOptions.concise().setJson(true).setFormatted(true))
 
-  val readWritten = read(descriptor[A] from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+  val readWritten = read(descriptor[A] from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
   assert(readWritten == zioConfigResult)
 
@@ -268,7 +268,7 @@ object ListExample extends App with EitherImpureOps {
       |          }
       |        ]
       |      }
-      |      
+      |
       |      {
       |        hi : di
       |        bi : ci
@@ -292,7 +292,7 @@ object ListExample extends App with EitherImpureOps {
       |          }
       |        ]
       |      }
-      |      
+      |
       |     {
       |        hi : di
       |        bi : ci
@@ -300,7 +300,7 @@ object ListExample extends App with EitherImpureOps {
       |      }
       |    ]
       |  }
-      |  
+      |
       |  {
       |    table          : some_name1
       |    columns        : []
@@ -322,20 +322,20 @@ object ListExample extends App with EitherImpureOps {
       |      }
       |    ]
       |  }
-      |  
+      |
       | {
       |    table          : some_name1
       |    columns        : []
       |    extra-details = []
       |  }
-      |  
+      |
       |   {
       |    table          : some_name2
       |    columns        : []
       |    extra-details  = []
       |  }
-      |  
-      |    
+      |
+      |
       |   {
       |    table          : some_name2
       |    columns        : []
@@ -370,7 +370,7 @@ object ListExample extends App with EitherImpureOps {
   final case class Database(port: Port)
 
   val kebabConfigSource =
-    TypeSafeConfigSource.fromHoconString(kebabCaseConfig).loadOrThrow
+    TypesafeConfigSource.fromHoconString(kebabCaseConfig).loadOrThrow
 
   val zioConfigWithKeysInKebabResult =
     read(descriptor[ExportDetails].mapKey(camelToKebab) from kebabConfigSource)

--- a/examples/src/main/scala/zio/config/examples/typesafe/MapExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/MapExample.scala
@@ -5,7 +5,7 @@ import zio.config._
 import typesafe._
 import ConfigDescriptor._
 import com.typesafe.config.ConfigRenderOptions
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 
 object MapExample extends App with EitherImpureOps {
   val hocon =
@@ -24,7 +24,7 @@ object MapExample extends App with EitherImpureOps {
        |  }
        |""".stripMargin
 
-  val source = TypeSafeConfigSource.fromHoconString(hocon).loadOrThrow
+  val source = TypesafeConfigSource.fromHoconString(hocon).loadOrThrow
 
   final case class sss(s: Map[String, List[Int]], l: List[Int], l2: List[Int], value: Map[String, String])
 
@@ -104,7 +104,7 @@ object MapExample extends App with EitherImpureOps {
        |""".stripMargin
 
   val result3 =
-    read(nested("result")(mapStrict(description)) from TypeSafeConfigSource.fromHoconString(hocon2).loadOrThrow)
+    read(nested("result")(mapStrict(description)) from TypesafeConfigSource.fromHoconString(hocon2).loadOrThrow)
 
   println(result3)
 
@@ -120,7 +120,7 @@ object MapExample extends App with EitherImpureOps {
 
   val xx = nested("k") { map("s")(string("y")) }
 
-  println(read(xx from TypeSafeConfigSource.fromHoconString(hocon3).loadOrThrow))
+  println(read(xx from TypesafeConfigSource.fromHoconString(hocon3).loadOrThrow))
 
   val hocon4 =
     s"""
@@ -129,7 +129,7 @@ object MapExample extends App with EitherImpureOps {
 
   val xx2 = nested("k") { map(string("y")) }
 
-  println(read(xx2 from TypeSafeConfigSource.fromHoconString(hocon4).loadOrThrow))
+  println(read(xx2 from TypesafeConfigSource.fromHoconString(hocon4).loadOrThrow))
 
   println(generateDocs(map("s")(string) from ConfigSource.fromMap(Map.empty)))
 

--- a/examples/src/main/scala/zio/config/examples/typesafe/NullAndOptionalConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/NullAndOptionalConfig.scala
@@ -2,7 +2,7 @@ package zio.config.examples.typesafe
 
 import zio.config.ConfigDescriptor
 import zio.config.read
-import zio.config.typesafe.TypeSafeConfigSource.fromHoconString
+import zio.config.typesafe.TypesafeConfigSource.fromHoconString
 import EmployeeDetails._
 import zio.config.ConfigDescriptor._
 

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigErrorsExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigErrorsExample.scala
@@ -1,6 +1,6 @@
 package zio.config.examples.typesafe
 
-import zio.config.typesafe.TypeSafeConfigSource
+import zio.config.typesafe.TypesafeConfigSource
 import zio.config.ConfigDescriptor.{ int, nested, string }
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
@@ -59,19 +59,19 @@ object TypesafeConfigErrorsExample extends App {
    """
 
   val nestedConfigAutomaticResult1 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithStringDb) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithStringDb) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedAutomatic from source)
     }
 
   val nestedConfigAutomaticResult2 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithDb) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithDb) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedAutomatic from source)
     }
 
   val nestedConfigAutomaticResult3 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithNoDatabaseAtAll) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithNoDatabaseAtAll) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedAutomatic from source)
     }
@@ -105,19 +105,19 @@ object TypesafeConfigErrorsExample extends App {
   }
 
   val nestedConfigManualResult1 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithDb) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithDb) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedManual from source)
     }
 
   val nestedConfigManualResult2 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithStringDb) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithStringDb) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedManual from source)
     }
 
   val nestedConfigManualResult3 =
-    TypeSafeConfigSource.fromHoconString(hocconStringWithNoDatabaseAtAll) match {
+    TypesafeConfigSource.fromHoconString(hocconStringWithNoDatabaseAtAll) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configNestedManual from source)
     }
@@ -142,7 +142,7 @@ object TypesafeConfigErrorsExample extends App {
   val configWithHoconSubstitution = descriptor[DatabaseDetails]
 
   val finalResult =
-    TypeSafeConfigSource.fromHoconString(hoconStringWithSubstitution) match {
+    TypesafeConfigSource.fromHoconString(hoconStringWithSubstitution) match {
       case Left(value)   => Left(value)
       case Right(source) => read(configWithHoconSubstitution from source)
     }

--- a/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigSimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/typesafe/TypesafeConfigSimpleExample.scala
@@ -3,7 +3,7 @@ package zio.config.examples.typesafe
 import zio.config.ConfigDescriptor.{ int, list, nested, string }
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
 import zio.config.read
-import zio.config.typesafe.TypeSafeConfigSource.fromHoconString
+import zio.config.typesafe.TypesafeConfigSource.fromHoconString
 import zio.config._
 
 object TypesafeConfigSimpleExample extends App {
@@ -126,7 +126,7 @@ object TypesafeConfigSimpleExample extends App {
           accountId: chris
       }
       {
-        
+
       }
     ]
 

--- a/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
@@ -30,7 +30,7 @@ object TypesafeConfig {
   )(implicit tagged: Tagged[A]): Layer[Throwable, Config[A]] =
     Config.fromConfigDescriptorM(
       ZIO
-        .fromEither(TypeSafeConfigSource.fromTypesafeConfig(conf))
+        .fromEither(TypesafeConfigSource.fromTypesafeConfig(conf))
         .map(configDescriptor from _)
         .mapError(error => new RuntimeException(error))
     )

--- a/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfigSource.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfigSource.scala
@@ -11,7 +11,7 @@ import zio.{ IO, Task, ZIO }
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
-object TypeSafeConfigSource {
+object TypesafeConfigSource {
   def fromDefaultLoader: Either[String, ConfigSource[String, String]] =
     fromTypesafeConfig(ConfigFactory.load.resolve)
 

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigMapSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigMapSpec.scala
@@ -20,7 +20,7 @@ object TypesafeConfigMapSpec
 
         },
         test("read nested typesafe config map using mapStrict") {
-          val source = TypeSafeConfigSource.fromHoconString(hocon2).loadOrThrow
+          val source = TypesafeConfigSource.fromHoconString(hocon2).loadOrThrow
           val result = read(
             nested("result")(mapStrict(sssDescription))(
               TypesafeConfigMapSpecUtils.Nested.apply,
@@ -51,7 +51,7 @@ object TypesafeConfigMapSpec
 
           val desc = (nested("k") { map("s")(string("y")) } |@| string("y"))(Cfg.apply, Cfg.unapply)
 
-          val result = read(desc from TypeSafeConfigSource.fromHoconString(hocon3).loadOrThrow)
+          val result = read(desc from TypesafeConfigSource.fromHoconString(hocon3).loadOrThrow)
 
           assert(result)(isRight(equalTo(Cfg(Map("dynamicKey" -> "z"), "z"))))
         },
@@ -72,7 +72,7 @@ object TypesafeConfigMapSpec
 
           val xx2 = nested("k") { map(string("y")) }
 
-          assert(read(xx2 from TypeSafeConfigSource.fromHoconString(hocon4).loadOrThrow))(
+          assert(read(xx2 from TypesafeConfigSource.fromHoconString(hocon4).loadOrThrow))(
             isRight(equalTo(Map("dynamicKey" -> "z", "dynamicKey2" -> "z2")))
           )
         }
@@ -96,7 +96,7 @@ object TypesafeConfigMapSpecUtils {
        |  }
        |""".stripMargin
 
-  val source: ConfigSource[String, String] = TypeSafeConfigSource.fromHoconString(hocon).loadOrThrow
+  val source: ConfigSource[String, String] = TypesafeConfigSource.fromHoconString(hocon).loadOrThrow
 
   final case class sss(s: Map[String, List[Int]], l: List[Int], l2: List[Int], value: Map[String, String])
 

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigReadWriteTest.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigReadWriteTest.scala
@@ -15,13 +15,13 @@ object TypesafeConfigReadWriteTest
           "Simple: read(descriptor from typesafeSource) == read(descriptor from write(descriptor, read(descriptor from typesafeSource)))"
         ) {
           val readSource =
-            read(string("a") from TypeSafeConfigSource.fromHoconString("a=b").loadOrThrow)
+            read(string("a") from TypesafeConfigSource.fromHoconString("a=b").loadOrThrow)
 
           val written =
             write(string("a"), "b").loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(string("a") from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(string("a") from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right("b"))))
         },
@@ -32,13 +32,13 @@ object TypesafeConfigReadWriteTest
             nested("a") { string("b") }
 
           val readSource =
-            read(config from TypeSafeConfigSource.fromHoconString("a : { b = c }").loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString("a : { b = c }").loadOrThrow)
 
           val written =
             write(config, "c").loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(config from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right("c"))))
         },
@@ -49,13 +49,13 @@ object TypesafeConfigReadWriteTest
             nested("a") { list("b") { string } }
 
           val readSource =
-            read(config from TypeSafeConfigSource.fromHoconString("a : { b = [c, c] }").loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString("a : { b = [c, c] }").loadOrThrow)
 
           val written =
             write(config, readSource.loadOrThrow).loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(config from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right(List("c", "c")))))
         },
@@ -66,13 +66,13 @@ object TypesafeConfigReadWriteTest
             nested("a") { list("b") { string } }
 
           val readSource =
-            read(config from TypeSafeConfigSource.fromHoconString("a : { b = [] }").loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString("a : { b = [] }").loadOrThrow)
 
           val written =
             write(config, readSource.loadOrThrow).loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(config from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right(Nil))))
         },
@@ -118,14 +118,14 @@ object TypesafeConfigReadWriteTest
           val config = (fConfig |@| deConfig)(Cfg.apply, Cfg.unapply)
 
           val readSource =
-            read(config from TypeSafeConfigSource.fromHoconString(hocon).loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString(hocon).loadOrThrow)
 
           val written =
             write(config, readSource.loadOrThrow).loadOrThrow.toHocon
               .render(ConfigRenderOptions.concise().setFormatted(true).setJson(false))
 
           val readWritten =
-            read(config from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(config from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right(expected))))
         },
@@ -139,7 +139,7 @@ object TypesafeConfigReadWriteTest
             write(sssDescription, readSource.loadOrThrow).loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(sssDescription from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(sssDescription from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(
             equalTo(
@@ -157,7 +157,7 @@ object TypesafeConfigReadWriteTest
             write(complexConfig, readSource.loadOrThrow).loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(complexConfig from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(complexConfig from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           val innerResult =
             sss(Map("melb" -> List(1), "syd" -> List(1, 2)), List(), List(1, 3, 3), Map("v" -> "a"))
@@ -174,13 +174,13 @@ object TypesafeConfigReadWriteTest
             string("a").optional
 
           val readSource =
-            read(optionalConfig from TypeSafeConfigSource.fromHoconString("b = 1").loadOrThrow)
+            read(optionalConfig from TypesafeConfigSource.fromHoconString("b = 1").loadOrThrow)
 
           val written =
             write(optionalConfig, readSource.loadOrThrow).loadOrThrow.toHocon.render()
 
           val readWritten =
-            read(optionalConfig from TypeSafeConfigSource.fromHoconString(written).loadOrThrow)
+            read(optionalConfig from TypesafeConfigSource.fromHoconString(written).loadOrThrow)
 
           assert((readWritten, readSource))(equalTo((readSource, Right(None))))
         },
@@ -198,7 +198,7 @@ object TypesafeConfigReadWriteTest
             read(complexDescription from ConfigSource.fromPropertyTree(writtenProperty, "tree")).loadOrThrow
 
           val readWrittenHocon =
-            read(complexDescription from TypeSafeConfigSource.fromHoconString(writtenHocon).loadOrThrow).loadOrThrow
+            read(complexDescription from TypesafeConfigSource.fromHoconString(writtenHocon).loadOrThrow).loadOrThrow
 
           assert((readWrittenHocon, readWrittenProperty, readComplexSource))(
             equalTo((readComplexSource, expectedResult, expectedResult))
@@ -224,7 +224,7 @@ object TypesafeConfigReadWriteTestUtils {
        |  }
        |""".stripMargin
 
-  val source: ConfigSource[String, String] = TypeSafeConfigSource.fromHoconString(hocon).loadOrThrow
+  val source: ConfigSource[String, String] = TypesafeConfigSource.fromHoconString(hocon).loadOrThrow
 
   final case class sss(s: Map[String, List[Int]], l: List[Int], l2: List[Int], value: Map[String, String])
 
@@ -284,5 +284,5 @@ object TypesafeConfigReadWriteTestUtils {
     )
 
   val complexSource: ConfigSource[String, String] =
-    TypeSafeConfigSource.fromHoconString(hocon2).loadOrThrow
+    TypesafeConfigSource.fromHoconString(hocon2).loadOrThrow
 }

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -9,7 +9,7 @@ object TypesafeConfigSpec extends DefaultRunnableSpec {
   val spec = suite("TypesafeConfig")(
     test("Read empty list") {
       val res =
-        TypeSafeConfigSource.fromHoconString(
+        TypesafeConfigSource.fromHoconString(
           """
             |a {
             |  b = "s"
@@ -24,7 +24,7 @@ object TypesafeConfigSpec extends DefaultRunnableSpec {
     },
     test("Read mixed list") {
       val res =
-        TypeSafeConfigSource.fromHoconString(
+        TypesafeConfigSource.fromHoconString(
           """
             |list = [
             |  "a",

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigTestSupport.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigTestSupport.scala
@@ -168,7 +168,7 @@ object TypesafeConfigTestSupport extends EitherSupport {
       |m = []
       |""".stripMargin
 
-  val complexHoconSource: ConfigSource[String, String] = TypeSafeConfigSource.fromHoconString(hocon).loadOrThrow
+  val complexHoconSource: ConfigSource[String, String] = TypesafeConfigSource.fromHoconString(hocon).loadOrThrow
 
   val complexDescription = descriptor[A]
   val readComplexSource  = read(complexDescription from complexHoconSource).loadOrThrow


### PR DESCRIPTION
I am not sure if this is a correct change but there you go.