### PR TITLE
partially fixes #322 - handle '=' in CLI argument's value

### DIFF
--- a/core/src/main/scala/zio/config/ConfigSourceModule.scala
+++ b/core/src/main/scala/zio/config/ConfigSourceModule.scala
@@ -422,8 +422,7 @@ trait ConfigSourceStringModule extends ConfigSourceModule {
       type KeyValue = These[Key, Value]
 
       object KeyValue {
-        def mk(s: String): Option[KeyValue] = {
-
+        def mk(s: String): Option[KeyValue] =
           splitAtFirstOccurence(s, "=") match {
             case (Some(possibleKey), Some(possibleValue)) =>
               Key.mk(possibleKey) match {
@@ -441,7 +440,6 @@ trait ConfigSourceStringModule extends ConfigSourceModule {
 
             case (None, None) => None
           }
-        }
 
         def splitAtFirstOccurence(text: String, char: String): (Option[String], Option[String]) = {
           val splitted = text.split(char, 2)

--- a/core/src/main/scala/zio/config/ConfigSourceModule.scala
+++ b/core/src/main/scala/zio/config/ConfigSourceModule.scala
@@ -423,9 +423,8 @@ trait ConfigSourceStringModule extends ConfigSourceModule {
 
       object KeyValue {
         def mk(s: String): Option[KeyValue] = {
-          val splitted = s.split('=').toList
 
-          (splitted.headOption, splitted.lift(1)) match {
+          splitAtFirstOccurence(s, "=") match {
             case (Some(possibleKey), Some(possibleValue)) =>
               Key.mk(possibleKey) match {
                 case Some(actualKey) => Some(Both(actualKey, Value(possibleValue)))
@@ -442,6 +441,11 @@ trait ConfigSourceStringModule extends ConfigSourceModule {
 
             case (None, None) => None
           }
+        }
+
+        def splitAtFirstOccurence(text: String, char: String): (Option[String], Option[String]) = {
+          val splitted = text.split(char, 2)
+          splitted.headOption.filterNot(_.isEmpty) -> splitted.lift(1)
         }
       }
 

--- a/core/src/test/scala/zio/config/CommandLineSourceTest.scala
+++ b/core/src/test/scala/zio/config/CommandLineSourceTest.scala
@@ -2,7 +2,7 @@ package zio.config
 
 import zio.config.ReadError.{ ConversionError, Step }
 import zio.config.testsupport.MapConfigTestSupport.AppConfig.descriptor
-import zio.config.testsupport.MapConfigTestSupport.{ genAppConfig, AppConfig }
+import zio.config.testsupport.MapConfigTestSupport.{ genAppConfig, stringNWithInjector, AppConfig }
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test.{ DefaultRunnableSpec, _ }
@@ -12,7 +12,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
   def spec: Spec[TestEnvironment, TestFailure[Nothing], TestSuccess] =
     suite("Configuration from command-line-style arguments")(
       testM("Configuration from arguments roundtrip separate args --key value") {
-        checkM(genAppConfig) { appConfig =>
+        checkM(genAppConfig()) { appConfig =>
           val p2: zio.IO[ReadError[String], AppConfig] =
             for {
               args   <- toSeparateArgs(AppConfig.descriptor, appConfig)
@@ -23,7 +23,7 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
         }
       },
       testM("Configuration from arguments roundtrip single arg --key=value") {
-        checkM(genAppConfig) { appConfig =>
+        checkM(genAppConfig()) { appConfig =>
           val p2: zio.IO[ReadError[String], AppConfig] =
             for {
               args   <- toSingleArg(AppConfig.descriptor, appConfig)
@@ -34,11 +34,22 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
         }
       },
       testM("Configuration from arguments roundtrip single arg --key=value multiple values take the head") {
-        checkM(genAppConfig) { appConfig =>
+        checkM(genAppConfig()) { appConfig =>
           val p2: zio.IO[ReadError[String], AppConfig] =
             for {
               args   <- toMultiSingleArg(AppConfig.descriptor, appConfig)
               reread <- fromArgs(args)
+            } yield reread.get
+
+          assertM(p2.either)(isRight(equalTo(appConfig)))
+        }
+      },
+      testM("Configuration from arguments roundtrip singe arg --key-value where value contains = char"){
+        checkM(genAppConfig(stringNWithInjector(1, 15, "="))){ appConfig =>
+          val p2: zio.IO[ReadError[String], AppConfig] =
+            for {
+            args <- toSingleArg(AppConfig.descriptor, appConfig)
+            reread <-fromArgs(args)
             } yield reread.get
 
           assertM(p2.either)(isRight(equalTo(appConfig)))

--- a/core/src/test/scala/zio/config/CommandLineSourceTest.scala
+++ b/core/src/test/scala/zio/config/CommandLineSourceTest.scala
@@ -44,12 +44,12 @@ object CommandLineSourceTest extends DefaultRunnableSpec {
           assertM(p2.either)(isRight(equalTo(appConfig)))
         }
       },
-      testM("Configuration from arguments roundtrip singe arg --key-value where value contains = char"){
-        checkM(genAppConfig(stringNWithInjector(1, 15, "="))){ appConfig =>
+      testM("Configuration from arguments roundtrip singe arg --key-value where value contains = char") {
+        checkM(genAppConfig(stringNWithInjector(1, 15, "="))) { appConfig =>
           val p2: zio.IO[ReadError[String], AppConfig] =
             for {
-            args <- toSingleArg(AppConfig.descriptor, appConfig)
-            reread <-fromArgs(args)
+              args   <- toSingleArg(AppConfig.descriptor, appConfig)
+              reread <- fromArgs(args)
             } yield reread.get
 
           assertM(p2.either)(isRight(equalTo(appConfig)))

--- a/core/src/test/scala/zio/config/MapConfigTest.scala
+++ b/core/src/test/scala/zio/config/MapConfigTest.scala
@@ -13,7 +13,7 @@ object MapConfigTest extends DefaultRunnableSpec {
   def spec: Spec[TestEnvironment, TestFailure[Nothing], TestSuccess] =
     suite("Configuration from Map")(
       testM("Configuration from Map roundtrip") {
-        checkM(genAppConfig) { appConfig =>
+        checkM(genAppConfig()) { appConfig =>
           val p2: zio.IO[ReadError[String], AppConfig] =
             for {
               args   <- toMap(AppConfig.descriptor, appConfig)

--- a/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
+++ b/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
@@ -111,19 +111,17 @@ object MapConfigTestSupport {
       s <- Gen.stringN(n)(alphaNumericChar)
     } yield s
 
-  def stringNWithInjector(min: 1, max: 15, inj: String): Gen[Random with Sized, String] = {
+  def stringNWithInjector(min: Int, max: Int, inj: String): Gen[Random with Sized, String] =
     for {
-      length <- Gen.int(min, max)
-      index <- Gen.int(0, length - 1)
+      length  <- Gen.int(min, max)
+      index   <- Gen.int(0, length - 1)
       decider <- Gen.boolean
-      text <- Gen.stringN(length)(alphaNumericChar).map(s => injectString(s, inj, index, decider))
+      text    <- Gen.stringN(length)(alphaNumericChar).map(s => injectString(s, inj, index, decider))
     } yield text
-  }
 
-  def injectString(text: String, inject: String, index: Int, randomizer: Boolean): String = {
-    if(randomizer) {
-        val (start, end) = text.splitAt(index)
-        s"$start$inject$end"
+  def injectString(text: String, inject: String, index: Int, randomizer: Boolean): String =
+    if (randomizer) {
+      val (start, end) = text.splitAt(index)
+      s"$start$inject$end"
     } else text
-  }
 }

--- a/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
+++ b/core/src/test/scala/zio/config/testsupport/MapConfigTestSupport.scala
@@ -6,12 +6,12 @@ import zio.test.Gen.alphaNumericChar
 import zio.test.{ Gen, Sized }
 
 object MapConfigTestSupport {
-  def genAppConfig: Gen[Random with Sized, AppConfig] =
+  def genAppConfig(stringGen: Gen[Random with Sized, String] = stringN(1, 15)): Gen[Random with Sized, AppConfig] =
     for {
-      strings   <- Gen.listOfN(10)(stringN(1, 15))
+      strings   <- Gen.listOfN(10)(stringGen)
       supervise <- Gen.boolean
     } yield AppConfig(
-      awsConfig = AppConfig.AwsConfig(strings(0), strings(1), AppConfig.KinesisConfig(strings(2))),
+      awsConfig = AppConfig.AwsConfig(strings.head, strings(1), AppConfig.KinesisConfig(strings(2))),
       pubSubConfig = AppConfig.PubSubConfig(strings(9)),
       jobConfig = JobConfig(
         dataflowConfig = Some(
@@ -111,4 +111,19 @@ object MapConfigTestSupport {
       s <- Gen.stringN(n)(alphaNumericChar)
     } yield s
 
+  def stringNWithInjector(min: 1, max: 15, inj: String): Gen[Random with Sized, String] = {
+    for {
+      length <- Gen.int(min, max)
+      index <- Gen.int(0, length - 1)
+      decider <- Gen.boolean
+      text <- Gen.stringN(length)(alphaNumericChar).map(s => injectString(s, inj, index, decider))
+    } yield text
+  }
+
+  def injectString(text: String, inject: String, index: Int, randomizer: Boolean): String = {
+    if(randomizer) {
+        val (start, end) = text.splitAt(index)
+        s"$start$inject$end"
+    } else text
+  }
 }

--- a/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
@@ -23,4 +23,30 @@ object SimpleExample extends App {
   assert(
     read((string("key1") |@| string("key2"))(A.apply, A.unapply) from source) == Right(A("value1", "value2"))
   )
+
+  /**
+   * Keys and Values could be also separated with '=' sign in such case valud could also contain '='
+   */
+  val cmdLineArgsWithEqualSeparator =
+    "--key1=value1 --key2=value2"
+
+  val source2 = ConfigSource.fromCommandLineArgs(cmdLineArgsWithEqualSeparator.split(' ').toList)
+
+  assert(
+    read(descriptor[A] from source2) == Right(A("value1", "value2"))
+  )
+
+  /**
+   * Values could contain '=' but only when key and value are separated also by equal sign.
+   */
+  val cmdLineArgsWithEqualInValue =
+    "--key1==1 --key2=value="
+
+  val source3 = ConfigSource.fromCommandLineArgs(cmdLineArgsWithEqualInValue.split(' ').toList)
+
+  assert {
+    read(descriptor[A] from source3) == Right(
+      A("=1", "value=")
+    )
+  }
 }

--- a/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/commandline/SimpleExample.scala
@@ -25,7 +25,7 @@ object SimpleExample extends App {
   )
 
   /**
-   * Keys and Values could be also separated with '=' sign in such case valud could also contain '='
+   * Keys and Values could be also separated with '='
    */
   val cmdLineArgsWithEqualSeparator =
     "--key1=value1 --key2=value2"


### PR DESCRIPTION
I've managed this partially only... 

assume cases:
`--key=valuewith=inside` or `--key valuewith=inside`

It's able to easy distinguish value when both key and value are separated with `=` sign. But in case where both are separated with space char it's rather impossible to guess whether `valuewith=inside` is entire value or it's key `valuewith` with value of `inside`.


