### PR TITLE
fix fromHoconString producing exception on parse error (#325)

### DIFF
--- a/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfigSource.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfigSource.scala
@@ -33,7 +33,7 @@ object TypesafeConfigSource {
     )
 
   def fromTypesafeConfig(
-    input: com.typesafe.config.Config
+    input: => com.typesafe.config.Config
   ): Either[String, ConfigSource] =
     Try {
       input

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
@@ -101,6 +101,17 @@ object TypesafeConfigErrorsSpec extends DefaultRunnableSpec {
       assert(nestedConfigAutomaticResult3)(equalTo(nestedConfigAutomaticExpect3)) &&
       assert(nestedConfigAutomaticResult4)(equalTo(nestedConfigAutomaticExpect4))
     },
+    test("A variant error case with a not well-formed typesafe HOCON config") {
+      val hocconStringWithParseError =
+        s"""
+         account {
+        """
+
+      val notWellFormedConfigResult = TypesafeConfigSource.fromHoconString(hocconStringWithParseError)
+      val notWellFormedConfigExpect = Left("String: 3: expecting a close parentheses ')' here, not: end of file")
+
+      assert(notWellFormedConfigResult)(equalTo(notWellFormedConfigExpect))
+    },
     test("A variant error case with typesafe HOCON config and a manual description") {
       val configNestedManual = {
         val accountConfig =

--- a/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
+++ b/typesafe/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
@@ -108,9 +108,8 @@ object TypesafeConfigErrorsSpec extends DefaultRunnableSpec {
         """
 
       val notWellFormedConfigResult = TypesafeConfigSource.fromHoconString(hocconStringWithParseError)
-      val notWellFormedConfigExpect = Left("String: 3: expecting a close parentheses ')' here, not: end of file")
 
-      assert(notWellFormedConfigResult)(equalTo(notWellFormedConfigExpect))
+      assert(notWellFormedConfigResult.isLeft)(Assertion.isTrue)
     },
     test("A variant error case with typesafe HOCON config and a manual description") {
       val configNestedManual = {


### PR DESCRIPTION
I have added a call-by-name for `fromTypesafeConfig` and a unit test to check that we get a Left value instead of an exception.

See issue #325 