### PR TITLE
shapeless-based derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,9 +55,10 @@ addCommandAlias(
 addCommandAlias("compileAll", "; ++2.11.12; root2-11/compile; ++2.12.11; root2-12/compile; ++2.13.2!; root2-13/compile")
 addCommandAlias("testAll", "; ++2.11.12; root2-11/test; ++2.12.11; root2-12/test; ++2.13.2!; root2-13/test")
 
-lazy val zioVersion      = "1.0.0-RC20"
-lazy val magnoliaVersion = "0.16.0"
-lazy val refinedVersion  = "0.9.14"
+lazy val zioVersion       = "1.0.0-RC20"
+lazy val magnoliaVersion  = "0.16.0"
+lazy val refinedVersion   = "0.9.14"
+lazy val shapelessVersion = "2.4.0-M1"
 
 lazy val magnoliaDependencies =
   libraryDependencies ++= {
@@ -75,7 +76,7 @@ lazy val refinedDependencies =
     else Seq("eu.timepit" %% "refined" % refinedVersion)
   }
 
-lazy val scala211projects = Seq[ProjectReference](zioConfig, zioConfigTypesafe)
+lazy val scala211projects = Seq[ProjectReference](zioConfig, zioConfigTypesafe, zioConfigShapeless, zioConfigDerivation)
 lazy val scala212projects = scala211projects ++ Seq[ProjectReference](
   zioConfigRefined,
   zioConfigMagnolia,
@@ -161,6 +162,9 @@ lazy val examples = module("zio-config-examples", "examples")
   )
   .dependsOn(zioConfig, zioConfigMagnolia, zioConfigRefined, zioConfigTypesafe)
 
+lazy val zioConfigDerivation = module("zio-config-derivation", "derivation")
+  .dependsOn(zioConfig)
+
 lazy val zioConfigMagnolia = module("zio-config-magnolia", "magnolia")
   .settings(
     magnoliaDependencies,
@@ -170,7 +174,19 @@ lazy val zioConfigMagnolia = module("zio-config-magnolia", "magnolia")
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
-  .dependsOn(zioConfig % "compile->compile;test->test")
+  .dependsOn(zioConfig % "compile->compile;test->test", zioConfigDerivation)
+
+lazy val zioConfigShapeless = module("zio-config-shapeless", "shapeless")
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio"        %% "zio-test"     % zioVersion % Test,
+      "dev.zio"        %% "zio-test-sbt" % zioVersion % Test,
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "com.chuusai"    %% "shapeless"    % shapelessVersion
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+  )
+  .dependsOn(zioConfig % "compile->compile;test->test", zioConfigDerivation)
 
 lazy val zioConfigTypesafe =
   module("zio-config-typesafe", "typesafe")

--- a/derivation/src/main/scala-2.11/zio/config/derivation/NeedsDerive.scala
+++ b/derivation/src/main/scala-2.11/zio/config/derivation/NeedsDerive.scala
@@ -1,0 +1,23 @@
+package zio.config.derivation
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "Can't derive ConfigDescriptor for `List[T]`, `Option[T]` or `Either[A, B]` directly." +
+    " Wrap it with a `case class Config(list: List[T])` or use `list(descriptor[T])` manually."
+)
+sealed trait NeedsDerive[+T]
+
+object NeedsDerive extends NeedsDerive[Nothing] {
+
+  implicit def needsDerive[R]: NeedsDerive[R] = NeedsDerive
+
+  implicit def needsDeriveAmbiguousList1: NeedsDerive[List[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousList2: NeedsDerive[List[Nothing]] = NeedsDerive
+
+  implicit def needsDeriveAmbiguousOption1: NeedsDerive[Option[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousOption2: NeedsDerive[Option[Nothing]] = NeedsDerive
+
+  implicit def needsDeriveAmbiguousEither1: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousEither2: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+}

--- a/derivation/src/main/scala-2.12/zio/config/derivation/NeedsDerive.scala
+++ b/derivation/src/main/scala-2.12/zio/config/derivation/NeedsDerive.scala
@@ -1,0 +1,35 @@
+package zio.config.derivation
+
+import scala.annotation.implicitAmbiguous
+
+/**
+ * Preventing derivation for List, Option and Either.
+ * */
+sealed trait NeedsDerive[+T]
+
+object NeedsDerive extends NeedsDerive[Nothing] {
+
+  implicit def needsDerive[R]: NeedsDerive[R] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `List[T]` directly." +
+      " Wrap it with a `case class Config(list: List[T])` or use `list(descriptor[T])` manually."
+  )
+  implicit def needsDeriveAmbiguousList1: NeedsDerive[List[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousList2: NeedsDerive[List[Nothing]] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `Option[T]` directly." +
+      " Wrap it with a `case class Config(list: Option[T])` or use `descriptor[T].optional` manually."
+  )
+  implicit def needsDeriveAmbiguousOption1: NeedsDerive[Option[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousOption2: NeedsDerive[Option[Nothing]] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `Either[A, B]` directly." +
+      " Wrap it with a `case class Config(list: Either[A, B])`" +
+      " or use `descriptor[A].orElseEither(descriptor[B])` manually."
+  )
+  implicit def needsDeriveAmbiguousEither1: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousEither2: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+}

--- a/derivation/src/main/scala-2.13/zio/config/derivation/NeedsDerive.scala
+++ b/derivation/src/main/scala-2.13/zio/config/derivation/NeedsDerive.scala
@@ -1,0 +1,35 @@
+package zio.config.derivation
+
+import scala.annotation.implicitAmbiguous
+
+/**
+ * Preventing derivation for List, Option and Either.
+ * */
+sealed trait NeedsDerive[+T]
+
+object NeedsDerive extends NeedsDerive[Nothing] {
+
+  implicit def needsDerive[R]: NeedsDerive[R] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `List[T]` directly." +
+      " Wrap it with a `case class Config(list: List[T])` or use `list(descriptor[T])` manually."
+  )
+  implicit def needsDeriveAmbiguousList1: NeedsDerive[List[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousList2: NeedsDerive[List[Nothing]] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `Option[T]` directly." +
+      " Wrap it with a `case class Config(list: Option[T])` or use `descriptor[T].optional` manually."
+  )
+  implicit def needsDeriveAmbiguousOption1: NeedsDerive[Option[Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousOption2: NeedsDerive[Option[Nothing]] = NeedsDerive
+
+  @implicitAmbiguous(
+    "Can't derive ConfigDescriptor for `Either[A, B]` directly." +
+      " Wrap it with a `case class Config(list: Either[A, B])`" +
+      " or use `descriptor[A].orElseEither(descriptor[B])` manually."
+  )
+  implicit def needsDeriveAmbiguousEither1: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+  implicit def needsDeriveAmbiguousEither2: NeedsDerive[Either[Nothing, Nothing]] = NeedsDerive
+}

--- a/derivation/src/main/scala/zio/config/derivation/DerivationUtils.scala
+++ b/derivation/src/main/scala/zio/config/derivation/DerivationUtils.scala
@@ -1,0 +1,44 @@
+package zio.config.derivation
+
+import zio.config._
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+object DerivationUtils {
+  case class ConstantString(value: String) extends PropertyType[String, String] {
+    def read(propertyValue: String): Either[PropertyType.PropertyReadError[String], String] =
+      if (propertyValue == value) Right(value)
+      else Left(PropertyType.PropertyReadError(propertyValue, s"constant string '$value'"))
+    def write(a: String): String = a
+  }
+
+  def constantString(value: String): ConfigDescriptor[String] =
+    ConfigDescriptorAdt.Source(ConfigSource.empty, ConstantString(value)) ?? s"constant string '$value'"
+
+  def constant[T](label: String, value: T): ConfigDescriptor[T] =
+    constantString(label)(_ => value, p => Some(p).filter(_ == value).map(_ => label))
+
+  def toSnakeCase(name: String): String = {
+    def addToAcc(acc: List[String], current: List[Int]) = {
+      def currentWord = current.reverse.flatMap(i => Character.toChars(i)).mkString.toLowerCase
+      if (current.isEmpty) acc
+      else if (acc.isEmpty) currentWord :: Nil
+      else currentWord :: "_" :: acc
+    }
+
+    @tailrec
+    def loop(chars: List[Int], acc: List[String], current: List[Int], beginning: Boolean): String =
+      chars match {
+        case Nil => addToAcc(acc, current).reverse.mkString
+        case head :: tail if beginning =>
+          loop(tail, acc, head :: current, Character.isUpperCase(head) || !Character.isLetter(head))
+        case head :: tail if Character.isUpperCase(head) =>
+          loop(tail, addToAcc(acc, current), head :: Nil, beginning = true)
+        case head :: tail =>
+          loop(tail, acc, head :: current, beginning = false)
+      }
+
+    loop(name.codePoints().iterator().asScala.map(x => x: Int).toList, Nil, Nil, beginning = true)
+  }
+}

--- a/derivation/src/main/scala/zio/config/derivation/annotations.scala
+++ b/derivation/src/main/scala/zio/config/derivation/annotations.scala
@@ -1,4 +1,4 @@
-package zio.config.magnolia
+package zio.config.derivation
 
 import scala.annotation.StaticAnnotation
 

--- a/magnolia/src/main/scala/zio/config/magnolia/package.scala
+++ b/magnolia/src/main/scala/zio/config/magnolia/package.scala
@@ -1,0 +1,8 @@
+package zio.config
+
+package object magnolia {
+  type describe = derivation.describe
+  val describe: derivation.describe.type = derivation.describe
+  type name = derivation.name
+  val name: derivation.name.type = derivation.name
+}

--- a/shapeless/src/main/scala/zio/config/shapeless/DeriveConfigDescriptor.scala
+++ b/shapeless/src/main/scala/zio/config/shapeless/DeriveConfigDescriptor.scala
@@ -1,0 +1,310 @@
+package zio.config.shapeless
+
+import java.io.File
+import java.net.{ URI, URL }
+import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime }
+import java.util.UUID
+
+import shapeless._
+import shapeless.labelled._
+import zio.config._
+import zio.config.derivation.DerivationUtils.constant
+import zio.config.derivation.{ DerivationUtils, NeedsDerive }
+import zio.duration.Duration
+
+import scala.concurrent.duration.{ Duration => ScalaDuration }
+import scala.reflect.ClassTag
+
+/**
+ * DeriveConfigDescriptor.descriptor[Config] gives an automatic ConfigDescriptor for the case class Config recursively
+ *
+ * DeriveConfigDescriptor.descriptor[X] gives an automatic ConfigDescriptor for the sealed trait X (coproduct)
+ *
+ * {{{
+ *
+ *    // Given
+ *    final case class Config(username: String, age: Int)
+ *
+ *    // should work with no additional code
+ *    val description = descriptor[Config]
+ *
+ *    val config = Config.fromSystemEnv(description)
+ *
+ * }}}
+ *
+ *
+ * Please find more (complex) examples in the examples module in zio-config
+ */
+object DeriveConfigDescriptor extends DeriveConfigDescriptor {
+  def mapClassName(name: String): String = toSnakeCase(name)
+  def mapFieldName(name: String): String = name
+
+  val wrapSealedTraitClasses: Boolean = true
+  val wrapSealedTraits: Boolean       = true
+
+  /**
+   * By default this method is not implicit to allow custom non-recursive derivation
+   * */
+  override implicit def descriptor[T: NeedsDerive: ClassDescriptor]: Descriptor[T] = super.descriptor[T]
+}
+
+/**
+ * Non-recursive derivation
+ *
+ * */
+object NonRecursiveDerivation extends DeriveConfigDescriptor {
+  def mapClassName(name: String): String = toSnakeCase(name)
+  def mapFieldName(name: String): String = name
+
+  val wrapSealedTraitClasses: Boolean = true
+  val wrapSealedTraits: Boolean       = true
+}
+
+trait DeriveConfigDescriptor {
+  import zio.config.ConfigDescriptor._
+
+  case class ClassDescriptor[T](desc: ConfigDescriptor[T], name: String, isObject: Boolean)
+
+  case class Descriptor[T](desc: ConfigDescriptor[T])
+
+  object Descriptor {
+    implicit def toConfigDescriptor[T](ev: Descriptor[T]): ConfigDescriptor[T] = ev.desc
+  }
+
+  protected def stringDesc: ConfigDescriptor[String]               = string
+  protected def booleanDesc: ConfigDescriptor[Boolean]             = boolean
+  protected def byteDesc: ConfigDescriptor[Byte]                   = byte
+  protected def shortDesc: ConfigDescriptor[Short]                 = short
+  protected def intDesc: ConfigDescriptor[Int]                     = int
+  protected def longDesc: ConfigDescriptor[Long]                   = long
+  protected def bigIntDesc: ConfigDescriptor[BigInt]               = bigInt
+  protected def floatDesc: ConfigDescriptor[Float]                 = float
+  protected def doubleDesc: ConfigDescriptor[Double]               = double
+  protected def bigDecimalDesc: ConfigDescriptor[BigDecimal]       = bigDecimal
+  protected def uriDesc: ConfigDescriptor[URI]                     = uri
+  protected def urlDesc: ConfigDescriptor[URL]                     = url
+  protected def scalaDurationDesc: ConfigDescriptor[ScalaDuration] = duration
+  protected def durationDesc: ConfigDescriptor[Duration]           = zioDuration
+  protected def uuidDesc: ConfigDescriptor[UUID]                   = uuid
+  protected def localDateDesc: ConfigDescriptor[LocalDate]         = localDate
+  protected def localTimeDesc: ConfigDescriptor[LocalTime]         = localTime
+  protected def localDateTimeDesc: ConfigDescriptor[LocalDateTime] = localDateTime
+  protected def instantDesc: ConfigDescriptor[Instant]             = instant
+  protected def fileDesc: ConfigDescriptor[File]                   = file
+
+  implicit val implicitStringDesc: Descriptor[String]               = Descriptor(stringDesc)
+  implicit val implicitBooleanDesc: Descriptor[Boolean]             = Descriptor(booleanDesc)
+  implicit val implicitByteDesc: Descriptor[Byte]                   = Descriptor(byteDesc)
+  implicit val implicitShortDesc: Descriptor[Short]                 = Descriptor(shortDesc)
+  implicit val implicitIntDesc: Descriptor[Int]                     = Descriptor(intDesc)
+  implicit val implicitLongDesc: Descriptor[Long]                   = Descriptor(longDesc)
+  implicit val implicitBigIntDesc: Descriptor[BigInt]               = Descriptor(bigIntDesc)
+  implicit val implicitFloatDesc: Descriptor[Float]                 = Descriptor(floatDesc)
+  implicit val implicitDoubleDesc: Descriptor[Double]               = Descriptor(doubleDesc)
+  implicit val implicitBigDecimalDesc: Descriptor[BigDecimal]       = Descriptor(bigDecimalDesc)
+  implicit val implicitUriDesc: Descriptor[URI]                     = Descriptor(uriDesc)
+  implicit val implicitUrlDesc: Descriptor[URL]                     = Descriptor(urlDesc)
+  implicit val implicitScalaDurationDesc: Descriptor[ScalaDuration] = Descriptor(scalaDurationDesc)
+  implicit val implicitDurationDesc: Descriptor[Duration]           = Descriptor(durationDesc)
+  implicit val implicitUUIDDesc: Descriptor[UUID]                   = Descriptor(uuidDesc)
+  implicit val implicitLocalDateDesc: Descriptor[LocalDate]         = Descriptor(localDateDesc)
+  implicit val implicitLocalTimeDesc: Descriptor[LocalTime]         = Descriptor(localTimeDesc)
+  implicit val implicitLocalDateTimeDesc: Descriptor[LocalDateTime] = Descriptor(localDateTimeDesc)
+  implicit val implicitInstantDesc: Descriptor[Instant]             = Descriptor(instantDesc)
+  implicit val implicitFileDesc: Descriptor[File]                   = Descriptor(fileDesc)
+
+  implicit def implicitListDesc[A: Descriptor]: Descriptor[List[A]] =
+    Descriptor(listDesc(implicitly[Descriptor[A]].desc))
+
+  implicit def implicitSetDesc[A: Descriptor]: Descriptor[Set[A]] =
+    Descriptor(setDesc(implicitly[Descriptor[A]].desc))
+
+  implicit def implicitMapDesc[A: Descriptor]: Descriptor[Map[String, A]] =
+    Descriptor(mapDesc(implicitly[Descriptor[A]].desc))
+
+  implicit def implicitEitherDesc[A: Descriptor, B: Descriptor]: Descriptor[Either[A, B]] =
+    Descriptor(eitherDesc(implicitly[Descriptor[A]].desc, implicitly[Descriptor[B]].desc))
+
+  implicit def implicitOptionDesc[A: Descriptor]: Descriptor[Option[A]] =
+    Descriptor(optionDesc(implicitly[Descriptor[A]].desc))
+
+  protected def listDesc[A](desc: ConfigDescriptor[A]): ConfigDescriptor[List[A]]       = list(desc)
+  protected def setDesc[A](desc: ConfigDescriptor[A]): ConfigDescriptor[Set[A]]         = set(desc)
+  protected def mapDesc[A](desc: ConfigDescriptor[A]): ConfigDescriptor[Map[String, A]] = map(desc)
+  protected def optionDesc[A](desc: ConfigDescriptor[A]): ConfigDescriptor[Option[A]]   = desc.optional
+
+  protected def eitherDesc[A, B](
+    left: ConfigDescriptor[A],
+    right: ConfigDescriptor[B]
+  ): ConfigDescriptor[Either[A, B]] =
+    left.orElseEither(right)
+
+  trait CollectClassFields[L <: HList, Names <: HList, Descs <: HList, Defaults <: HList] {
+    def apply(names: Names, descs: Descs, defaults: Defaults): ConfigDescriptor[L]
+  }
+
+  object CollectClassFields {
+    private def makeDescriptor[V](
+      desc: Descriptor[V],
+      manualName: Option[name],
+      fieldName: String,
+      defaultValue: Option[V],
+      description: Option[describe]
+    ) = {
+      val name         = manualName.map(_.name).getOrElse(mapFieldName(fieldName))
+      val withDefaults = defaultValue.fold(desc.desc)(desc.default(_))
+      val described    = description.map(_.describe).toSeq.foldLeft(withDefaults)(_ ?? _)
+      nested(name)(described)
+    }
+
+    implicit def caseHNil[K <: Symbol, V, N, Ds, Df](
+      implicit key: Witness.Aux[K],
+      desc: Descriptor[V],
+      evN: N <:< Option[name],
+      evDs: Ds <:< Option[describe],
+      evDf: Df <:< Option[V]
+    ): CollectClassFields[FieldType[K, V] :: HNil, N :: HNil, Ds :: HNil, Df :: HNil] =
+      (names, descs, defaults) => {
+        val fieldDesc = makeDescriptor(
+          desc = desc,
+          manualName = evN(names.head),
+          fieldName = key.value.name,
+          defaultValue = evDf(defaults.head),
+          description = evDs(descs.head)
+        )
+        fieldDesc.xmap(field[K](_) :: HNil, _.head)
+      }
+
+    implicit def caseHCons[K <: Symbol, V, T <: HList, N, Ds, Df, TN <: HList, TDs <: HList, TDf <: HList](
+      implicit key: Witness.Aux[K],
+      desc: Descriptor[V],
+      evN: N <:< Option[name],
+      evDs: Ds <:< Option[describe],
+      evDf: Df <:< Option[V],
+      next: CollectClassFields[T, TN, TDs, TDf]
+    ): CollectClassFields[FieldType[K, V] :: T, N :: TN, Ds :: TDs, Df :: TDf] =
+      (names, descs, defaults) => {
+        val fieldDesc = makeDescriptor(
+          desc = desc,
+          manualName = evN(names.head),
+          fieldName = key.value.name,
+          defaultValue = evDf(defaults.head),
+          description = evDs(descs.head)
+        )
+        (fieldDesc |@| next(names.tail, descs.tail, defaults.tail))(
+          (v, t) => field[K](v) :: t,
+          l => Some((l.head, l.tail))
+        )
+      }
+  }
+
+  trait OptAnnotation[A, T] {
+    def apply(): Option[A]
+  }
+
+  trait LowPriorityOptAnnotation {
+    implicit def caseNone[A, T]: OptAnnotation[A, T] = () => None
+  }
+
+  object OptAnnotation extends LowPriorityOptAnnotation {
+    implicit def caseSome[A, T](implicit an: Annotation[A, T]): OptAnnotation[A, T] = () => Some(an())
+  }
+
+  implicit def objectDescriptor[T](
+    implicit gen: LabelledGeneric.Aux[T, HNil],
+    typeName: TypeName[T],
+    optName: OptAnnotation[name, T],
+    optDesc: OptAnnotation[describe, T]
+  ): ClassDescriptor[T] = {
+    val ccName = optName().map(_.name).getOrElse(mapClassName(typeName()))
+    val desc   = constant[T](ccName, gen.from(HNil))
+    ClassDescriptor(optDesc().map(_.describe).fold(desc)(desc ?? _), ccName, isObject = true)
+  }
+
+  implicit def classDescriptor[T, Repr <: HList, Names <: HList, Descs <: HList, Defaults <: HList](
+    implicit gen: LabelledGeneric.Aux[T, Repr],
+    typeName: TypeName[T],
+    optName: OptAnnotation[name, T],
+    optDesc: OptAnnotation[describe, T],
+    names: Annotations.Aux[name, T, Names],
+    descs: Annotations.Aux[describe, T, Descs],
+    defaults: Default.Aux[T, Defaults],
+    collectFields: CollectClassFields[Repr, Names, Descs, Defaults]
+  ): ClassDescriptor[T] = {
+    val ccName = optName().map(_.name).getOrElse(mapClassName(typeName()))
+
+    val desc = collectFields(names(), descs(), defaults()).xmap(gen.from, gen.to)
+
+    ClassDescriptor(optDesc().map(_.describe).fold(desc)(desc ?? _), ccName, isObject = false)
+  }
+
+  trait SumCase[C] {
+    def desc: ClassDescriptor[C]
+    def cast(a: Any): Option[C]
+  }
+
+  trait CollectSum[Repr <: Coproduct] {
+    def apply(): List[SumCase[_]]
+  }
+
+  object CollectSum {
+    implicit val caseCNil: CollectSum[CNil] = () => Nil
+    implicit def caseCCons[H, T <: Coproduct](
+      implicit desc0: ClassDescriptor[H],
+      ct: ClassTag[H],
+      next: CollectSum[T]
+    ): CollectSum[H :+: T] =
+      () =>
+        new SumCase[H] {
+          val desc: ClassDescriptor[H] = desc0
+          def cast(a: Any): Option[H] = a match {
+            case h: H => Some(h)
+            case _    => None
+          }
+        } :: next()
+  }
+
+  implicit def sumDescriptor[T, Repr <: Coproduct](
+    implicit gen: Generic.Aux[T, Repr],
+    cs: CollectSum[Repr],
+    typeName: TypeName[T],
+    optName: OptAnnotation[name, T]
+  ): ClassDescriptor[T] = {
+    val _ = gen
+
+    def mapCase[C](sc: SumCase[C]) = {
+      val desc =
+        if (sc.desc.isObject || !wrapSealedTraitClasses) sc.desc.desc
+        else nested(sc.desc.name)(sc.desc.desc)
+
+      wrapSealedTrait(optName().map(_.name).getOrElse(mapClassName(typeName())), desc).xmapEither[T](
+        st => Right(st.asInstanceOf[T]),
+        t => sc.cast(t).map(Right(_)).getOrElse(Left(s"Expected ${sc.desc.name}, but got ${t.getClass.getName}"))
+      )
+
+    }
+
+    val desc = cs().map(mapCase(_)).reduce(_.orElse(_))
+    ClassDescriptor(desc, typeName(), isObject = false)
+  }
+
+  def toSnakeCase(name: String): String = DerivationUtils.toSnakeCase(name)
+
+  def mapClassName(name: String): String
+
+  def mapFieldName(name: String): String
+
+  def wrapSealedTraitClasses: Boolean
+
+  def wrapSealedTraits: Boolean
+
+  final def wrapSealedTrait[T](
+    label: String,
+    desc: ConfigDescriptor[T]
+  ): ConfigDescriptor[T] =
+    if (wrapSealedTraits) nested(label)(desc)
+    else desc
+
+  def descriptor[T: NeedsDerive: ClassDescriptor]: Descriptor[T] = Descriptor(implicitly[ClassDescriptor[T]].desc)
+  def apply[T: NeedsDerive: ClassDescriptor]: Descriptor[T]      = descriptor[T]
+}

--- a/shapeless/src/main/scala/zio/config/shapeless/TypeName.scala
+++ b/shapeless/src/main/scala/zio/config/shapeless/TypeName.scala
@@ -1,0 +1,20 @@
+package zio.config.shapeless
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+trait TypeName[T] {
+  def apply(): String
+}
+
+object TypeName {
+  implicit def materializeTypeName[T]: TypeName[T] = macro typeNameImpl[T]
+
+  def typeNameImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    val T    = c.weakTypeOf[T]
+    val name = T.typeSymbol.name.toString
+    q" new _root_.zio.config.shapeless.TypeName[$T]{ def apply(): String = $name } "
+  }
+}

--- a/shapeless/src/main/scala/zio/config/shapeless/package.scala
+++ b/shapeless/src/main/scala/zio/config/shapeless/package.scala
@@ -1,0 +1,8 @@
+package zio.config
+
+package object shapeless {
+  type describe = derivation.describe
+  val describe: derivation.describe.type = derivation.describe
+  type name = derivation.name
+  val name: derivation.name.type = derivation.name
+}

--- a/shapeless/src/test/scala/zio/config/shapeless/AutomaticConfigDescriptorSpec.scala
+++ b/shapeless/src/test/scala/zio/config/shapeless/AutomaticConfigDescriptorSpec.scala
@@ -1,0 +1,154 @@
+package zio.config.shapeless
+
+import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset }
+import java.util.UUID
+
+import zio.config._
+import zio.config.{ BaseSpec, ConfigSource, PropertyTree }
+import zio.config.shapeless.DeriveConfigDescriptor._
+import AutomaticConfigTestUtils._
+import zio.ZIO
+import zio.random.Random
+import zio.test._
+import zio.config.helpers._
+import zio.test.Assertion._
+
+object AutomaticConfigTest
+    extends BaseSpec(
+      suite("shapeless spec")(
+        testM("automatic derivation spec") {
+          checkM(genEnvironment) {
+            environment =>
+              val configDesc = descriptor[MyConfig]
+
+              val source =
+                ConfigSource.fromMap(environment, keyDelimiter = Some('.'))
+
+              val readAndWrite: ZIO[Any, Any, Either[String, PropertyTree[String, String]]] =
+                for {
+                  result  <- ZIO.fromEither(read(configDesc from source))
+                  written <- ZIO.effectTotal(write(configDesc, result))
+                } yield written
+
+              val defaultValue   = environment.getOrElse("default", "1")
+              val anotherDefault = environment.getOrElse("anotherDefault", "true")
+
+              val updatedEnv =
+                environment
+                  .updated("default", defaultValue)
+                  .updated("anotherDefault", anotherDefault)
+
+              val actual = readAndWrite
+                .map(_.map(_.flattenString()))
+                .map(_.fold(_ => Nil, fromMultiMap(_).toList.sortBy(_._1)))
+
+              assertM(actual)(equalTo(updatedEnv.toList.sortBy(_._1)))
+          }
+        }
+      )
+    )
+
+object AutomaticConfigTestUtils {
+  sealed trait Credentials
+  case class Password(value: String) extends Credentials
+  case class Token(value: String)    extends Credentials
+
+  sealed trait Price
+  case class Description(value: String) extends Price
+  case class Currency(value: Double)    extends Price
+
+  final case class Aws(region: String, security: Credentials)
+
+  final case class DbUrl(dburl: String) extends AnyVal
+
+  final case class MyConfig(
+    aws: Aws,
+    cost: Price,
+    dburl: DbUrl,
+    port: Int,
+    amount: Option[Long],
+    quantity: Either[Long, String],
+    default: Int = 1,
+    anotherDefault: Boolean = true,
+    descriptions: List[String],
+    created: LocalDate,
+    updated: LocalTime,
+    lastVisited: LocalDateTime,
+    id: UUID
+  )
+
+  private val genPriceDescription                = genNonEmptyString(5).map(Description)
+  private val genCurrency: Gen[Random, Currency] = Gen.double(10.0, 20.0).map(Currency)
+  private val genPrice: Gen[Random, Price]       = Gen.oneOf(genPriceDescription, genCurrency)
+
+  private val genToken       = genNonEmptyString(5).map(Token)
+  private val genPassword    = genNonEmptyString(5).map(Password)
+  private val genCredentials = Gen.oneOf(genToken, genPassword)
+
+  private val genDbUrl = genNonEmptyString(5).map(DbUrl)
+
+  private val genAws =
+    for {
+      region      <- genNonEmptyString(5)
+      credentials <- genCredentials
+    } yield Aws(region, credentials)
+
+  private[shapeless] val genEnvironment =
+    for {
+      aws            <- genAws
+      price          <- genPrice
+      dbUrl          <- genDbUrl
+      port           <- Gen.anyInt
+      amount         <- Gen.option(Gen.long(1, 100))
+      quantity       <- Gen.either(Gen.long(5, 10), genAlpha)
+      default        <- Gen.option(Gen.anyInt)
+      anotherDefault <- Gen.option(Gen.boolean)
+      descriptions   <- Gen.listOfBounded(1, 10)(Gen.anyString)
+      created        <- genLocalDateString
+      updated        <- genLocalTimeString
+      lastVisited    <- genLocalDateTimeString
+      id             <- Gen.anyUUID
+      partialMyConfig = Map(
+        "aws.region" -> aws.region,
+        aws.security match {
+          case Password(password) => "aws.security.credentials.password.value" -> password
+          case Token(token)       => "aws.security.credentials.token.value"    -> token
+        },
+        price match {
+          case Description(description) => "cost.price.description.value" -> description
+          case Currency(dollars)        => "cost.price.currency.value"    -> dollars.toString
+        },
+        "dburl.dburl"  -> dbUrl.dburl,
+        "port"         -> port.toString,
+        "quantity"     -> quantity.fold(d => d.toString, s => s),
+        "descriptions" -> descriptions.toString,
+        "created"      -> created,
+        "updated"      -> updated,
+        "lastVisited"  -> lastVisited,
+        "id"           -> id.toString
+      ) ++ amount.map(double => ("amount", double.toString)).toList
+    } yield (default, anotherDefault) match {
+      case (Some(v1), Some(v2)) => partialMyConfig ++ List(("default", v1.toString), ("anotherDefault", v2.toString))
+      case (Some(v1), None)     => partialMyConfig + (("default", v1.toString))
+      case (None, Some(v2))     => partialMyConfig + (("anotherDefault", v2.toString))
+      case (None, None)         => partialMyConfig
+    }
+
+  def genAlpha: Gen[Random, String] =
+    for {
+      n <- Gen.int(1, 10) // zio-config supports only cons hence starting with 1
+      s <- Gen.listOfN(n)(Gen.char(65, 122))
+    } yield s.mkString
+
+  val genInstant: Gen[Random, Instant] =
+    Gen.anyLong.map(Instant.ofEpochMilli)
+
+  val genLocalDateString: Gen[Random with Sized, String] =
+    genInstant.map(_.atZone(ZoneOffset.UTC).toLocalDate.toString)
+
+  val genLocalDateTimeString: Gen[Random with Sized, String] =
+    genInstant.map(_.atZone(ZoneOffset.UTC).toLocalDateTime.toString)
+
+  val genLocalTimeString: Gen[Random with Sized, String] =
+    genInstant.map(_.atZone(ZoneOffset.UTC).toLocalTime.toString)
+}

--- a/shapeless/src/test/scala/zio/config/shapeless/DerivationTest.scala
+++ b/shapeless/src/test/scala/zio/config/shapeless/DerivationTest.scala
@@ -1,0 +1,168 @@
+package zio.config.shapeless
+
+import zio.config._, ConfigDescriptorAdt._
+import zio.config.PropertyTree
+import zio.config.PropertyTree.Leaf
+import zio.config.PropertyTree.Record
+import zio.config.ConfigSource
+import zio.config.shapeless.DeriveConfigDescriptor.descriptor
+import zio.test.Assertion._
+import zio.test._
+
+object DerivationTest extends DefaultRunnableSpec {
+  val spec = suite("DerivationTest")(
+    test("support describe annotation") {
+      @describe("class desc")
+      case class Cfg(@describe("field desc") fname: String)
+
+      def collectDescriptions[T](
+        desc: ConfigDescriptor[T],
+        path: Option[String]
+      ): List[(Option[String], String)] = desc match {
+        case Default(config, _)        => collectDescriptions(config, path)
+        case DynamicMap(_, config)     => collectDescriptions(config, path)
+        case Describe(config, message) => (path, message) :: collectDescriptions(config, path)
+        case Nested(path, config)      => collectDescriptions(config, Some(path))
+        case Optional(config)          => collectDescriptions(config, path)
+        case OrElse(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case OrElseEither(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case Sequence(_, config) => collectDescriptions(config, path)
+        case Source(_, _)        => Nil
+        case Zip(left, right) =>
+          collectDescriptions(left, path) ::: collectDescriptions(right, path)
+        case XmapEither(config, _, _) => collectDescriptions(config, path)
+      }
+
+      assert(collectDescriptions(descriptor[Cfg], None))(
+        contains((None: Option[String]) -> "class desc") &&
+          contains(Some("fname")        -> "field desc")
+      )
+    },
+    test("support name annotation") {
+      @name("SealedTrait")
+      sealed trait St
+      @name("className")
+      case class Cfg(@name("otherName") fname: String) extends St
+
+      def collectPath[T](desc: ConfigDescriptor[T]): List[String] = desc match {
+        case Default(config, _)        => collectPath(config)
+        case Describe(config, _)       => collectPath(config)
+        case DynamicMap(_, config)     => collectPath(config)
+        case Nested(path, config)      => path :: collectPath(config)
+        case Optional(config)          => collectPath(config)
+        case OrElse(left, right)       => collectPath(left) ::: collectPath(right)
+        case OrElseEither(left, right) => collectPath(left) ::: collectPath(right)
+        case Sequence(_, config)       => collectPath(config)
+        case Source(_, _)              => Nil
+        case Zip(left, right)          => collectPath(left) ::: collectPath(right)
+        case XmapEither(config, _, _)  => collectPath(config)
+      }
+
+      assert(collectPath(descriptor[St]))(equalTo("SealedTrait" :: "className" :: "otherName" :: Nil))
+    },
+    test("support default value") {
+      @describe("class desc")
+      case class Cfg(fname: String = "defaultV")
+
+      def collectDefault[T](
+        desc: ConfigDescriptor[T],
+        path: Option[String]
+      ): List[(Option[String], Any)] = desc match {
+        case Default(config, v)    => (path -> v) :: collectDefault(config, path)
+        case Describe(config, _)   => collectDefault(config, path)
+        case DynamicMap(_, config) => collectDefault(config, path)
+        case Nested(path, config)  => collectDefault(config, Some(path))
+        case Optional(config)      => collectDefault(config, path)
+        case OrElse(left, right)   => collectDefault(left, path) ::: collectDefault(right, path)
+        case OrElseEither(left, right) =>
+          collectDefault(left, path) ::: collectDefault(right, path)
+        case Sequence(_, config)      => collectDefault(config, path)
+        case Source(_, _)             => Nil
+        case Zip(left, right)         => collectDefault(left, path) ::: collectDefault(right, path)
+        case XmapEither(config, _, _) => collectDefault(config, path)
+      }
+
+      assert(collectDefault(descriptor[Cfg], None))(equalTo((Some("fname"), "defaultV") :: Nil))
+    },
+    test("support lists recursive") {
+      case class A1(a: List[String])
+      case class A2(a: List[A1])
+      case class A3(a: List[A2])
+      case class A4(a: List[A3])
+      case class A5(a: List[A4])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Record(Map("a" -> PropertyTree.Sequence(List(loop(depth - 1)))))
+        else Leaf("str")
+
+      val src = ConfigSource.fromPropertyTree(loop(5), "tree")
+
+      val res = read(descriptor[A5] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support lists non-recursive") {
+      import NonRecursiveDerivation.descriptor
+      import NonRecursiveListHelper._
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) Record(Map("a" -> PropertyTree.Sequence(List(loop(depth - 1)))))
+        else Leaf("str")
+
+      val src = ConfigSource.fromPropertyTree(loop(5), "tree")
+
+      val res = read(descriptor[A5] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support nested lists non-recursive") {
+      import NonRecursiveDerivation.{ descriptor, Descriptor }
+
+      case class A(a: List[String])
+      implicit val cA: Descriptor[A] = descriptor[A]
+      val _                          = cA
+      case class B(a: List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) PropertyTree.Sequence(List(loop(depth - 1)))
+        else Record(Map("a" -> PropertyTree.Sequence(List(Leaf("s")))))
+
+      val src = ConfigSource.fromPropertyTree(Record(Map("a" -> loop(10))), "tree")
+
+      val res = read(descriptor[B] from src)
+
+      assert(res)(isRight(anything))
+    },
+    test("support nested lists recursive") {
+      case class A(a: List[String])
+      case class B(a: List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]])
+
+      def loop(depth: Int): PropertyTree[String, String] =
+        if (depth > 0) PropertyTree.Sequence(List(loop(depth - 1)))
+        else Record(Map("a" -> PropertyTree.Sequence(List(Leaf("s")))))
+
+      val src = ConfigSource.fromPropertyTree(Record(Map("a" -> loop(10))), "tree")
+
+      val res = read(descriptor[B] from src)
+
+      assert(res)(isRight(anything))
+    }
+  )
+}
+
+object NonRecursiveListHelper {
+  import NonRecursiveDerivation.{ descriptor, Descriptor }
+
+  case class A1(a: List[String])
+  implicit val cA1: Descriptor[A1] = descriptor[A1]
+  case class A2(a: List[A1])
+  implicit val cA2: Descriptor[A2] = descriptor[A2]
+  case class A3(a: List[A2])
+  implicit val cA3: Descriptor[A3] = descriptor[A3]
+  case class A4(a: List[A3])
+  implicit val cA4: Descriptor[A4] = descriptor[A4]
+  case class A5(a: List[A4])
+
+}

--- a/shapeless/src/test/scala/zio/config/shapeless/OverrideDerivationTest.scala
+++ b/shapeless/src/test/scala/zio/config/shapeless/OverrideDerivationTest.scala
@@ -1,0 +1,108 @@
+package zio.config.shapeless
+
+import zio.config.PropertyTree.{ Leaf, Record, Sequence }
+import zio.config.ConfigSource
+import zio.test.Assertion._
+import zio.test._
+import zio.config._
+
+object OverrideDerivationTestEnv extends DeriveConfigDescriptor {
+  override def mapClassName(name: String): String = toSnakeCase(name) + "_suffix"
+  override def mapFieldName(name: String): String = "prefix_" + toSnakeCase(name)
+
+  val wrapSealedTraitClasses: Boolean = false
+  val wrapSealedTraits: Boolean       = false
+}
+
+object OverrideDerivationTest extends DefaultRunnableSpec {
+  val spec = suite("OverrideDerivationTest")(
+    test("simple config") {
+      import OverrideDerivationTestEnv._
+
+      case class Cfg(fieldName: String)
+
+      val res = write(descriptor[Cfg], Cfg("a"))
+
+      assert(res)(isRight(equalTo(Record(Map("prefix_field_name" -> Leaf("a")))))) &&
+      assert(res.map(ConfigSource.fromPropertyTree(_, "tree")).flatMap(v => read(descriptor[Cfg] from v)))(
+        isRight(equalTo(Cfg("a")))
+      )
+    },
+    test("unwrapped sealed hierarchy") {
+      import OverrideDerivationTestEnv._
+
+      sealed trait Inner
+      case object Obj1Name                     extends Inner
+      case object OtherOBJECT                  extends Inner
+      case class ClassWithData(data: String)   extends Inner
+      case class ClassWithValue(value: String) extends Inner
+
+      case class Outer(list: List[Inner])
+
+      implicit val cInner: Descriptor[Inner] = descriptor[Inner]
+
+      val _ = cInner
+
+      val cfg = Outer(List(OtherOBJECT, Obj1Name, ClassWithValue("a"), ClassWithData("b")))
+
+      val res = write(OverrideDerivationTestEnv.descriptor[Outer], cfg)
+
+      val expected = Record(
+        Map(
+          "prefix_list" -> Sequence(
+            List(
+              Leaf("other_object_suffix"),
+              Leaf("obj1_name_suffix"),
+              Record(Map("prefix_value" -> Leaf("a"))),
+              Record(Map("prefix_data"  -> Leaf("b")))
+            )
+          )
+        )
+      )
+
+      assert(res)(isRight(equalTo(expected))) &&
+      assert(
+        res.map(ConfigSource.fromPropertyTree(_, "tree")).flatMap(v => read(descriptor[Outer] from v))
+      )(
+        isRight(equalTo(cfg))
+      )
+    },
+    test("wrapped sealed hierarchy") {
+      import DeriveConfigDescriptor._
+
+      sealed trait Inner
+      case object Obj1Name                     extends Inner
+      case object OtherOBJECT                  extends Inner
+      case class ClassWithData(data: String)   extends Inner
+      case class ClassWithValue(value: String) extends Inner
+
+      case class Outer(list: List[Inner])
+
+      val cfg = Outer(List(OtherOBJECT, Obj1Name, ClassWithValue("a"), ClassWithData("b")))
+
+      val res = write(descriptor[Outer], cfg)
+
+      val expected = Record(
+        Map(
+          "list" -> Sequence(
+            List(
+              Record(Map("inner" -> Leaf("other_object"))),
+              Record(Map("inner" -> Leaf("obj1_name"))),
+              Record(Map("inner" -> Record(Map("class_with_value" -> Record(Map("value" -> Leaf("a"))))))),
+              Record(Map("inner" -> Record(Map("class_with_data" -> Record(Map("data" -> Leaf("b")))))))
+            )
+          )
+        )
+      )
+
+      assert(res)(isRight(equalTo(expected))) &&
+      assert(
+        res
+          .map(ConfigSource.fromPropertyTree(_, "tree"))
+          .flatMap(v => read(DeriveConfigDescriptor.descriptor[Outer] from v))
+      )(
+        isRight(equalTo(cfg))
+      )
+    }
+  )
+}


### PR DESCRIPTION
Create `zio-config-shapeless` as a drop-in replacement for `zio-config-magnolia`.
Unlike `magnolia` it supports all required `scala` versions.