### PR TITLE
Add support for reading YAML files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,6 +200,18 @@ lazy val zioConfigTypesafe =
     )
     .dependsOn(zioConfig % "compile->compile;test->test")
 
+lazy val zioConfigYaml =
+  module("zio-config-yaml", "yaml")
+    .settings(
+      libraryDependencies ++= Seq(
+        "org.snakeyaml"     %  "snakeyaml-engine"    % "2.1",
+        "dev.zio"      %% "zio-test"     % zioVersion % Test,
+        "dev.zio"      %% "zio-test-sbt" % zioVersion % Test
+      ),
+      testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+    )
+    .dependsOn(zioConfig % "compile->compile;test->test")
+
 lazy val zioConfigTypesafeMagnoliaTests =
   module("zio-config-typesafe-magnolia-tests", "typesafe-magnolia-tests")
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,8 @@ lazy val refinedDependencies =
     else Seq("eu.timepit" %% "refined" % refinedVersion)
   }
 
-lazy val scala211projects = Seq[ProjectReference](zioConfig, zioConfigTypesafe, zioConfigShapeless, zioConfigDerivation)
+lazy val scala211projects =
+  Seq[ProjectReference](zioConfig, zioConfigTypesafe, zioConfigShapeless, zioConfigDerivation, zioConfigYaml)
 lazy val scala212projects = scala211projects ++ Seq[ProjectReference](
   zioConfigRefined,
   zioConfigMagnolia,
@@ -204,9 +205,9 @@ lazy val zioConfigYaml =
   module("zio-config-yaml", "yaml")
     .settings(
       libraryDependencies ++= Seq(
-        "org.snakeyaml" %  "snakeyaml-engine" % "2.1",
-        "dev.zio"       %% "zio-test"         % zioVersion % Test,
-        "dev.zio"       %% "zio-test-sbt"     % zioVersion % Test
+        "org.snakeyaml" % "snakeyaml-engine" % "2.1",
+        "dev.zio"       %% "zio-test"        % zioVersion % Test,
+        "dev.zio"       %% "zio-test-sbt"    % zioVersion % Test
       ),
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
     )

--- a/build.sbt
+++ b/build.sbt
@@ -204,9 +204,9 @@ lazy val zioConfigYaml =
   module("zio-config-yaml", "yaml")
     .settings(
       libraryDependencies ++= Seq(
-        "org.snakeyaml"     %  "snakeyaml-engine"    % "2.1",
-        "dev.zio"      %% "zio-test"     % zioVersion % Test,
-        "dev.zio"      %% "zio-test-sbt" % zioVersion % Test
+        "org.snakeyaml" %  "snakeyaml-engine" % "2.1",
+        "dev.zio"       %% "zio-test"         % zioVersion % Test,
+        "dev.zio"       %% "zio-test-sbt"     % zioVersion % Test
       ),
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
     )

--- a/yaml/src/main/scala/zio/config/yaml/YamlConfig.scala
+++ b/yaml/src/main/scala/zio/config/yaml/YamlConfig.scala
@@ -1,0 +1,23 @@
+package zio.config.yaml
+
+import java.io.File
+import java.nio.file.Path
+
+import zio.{ Tag, ZLayer }
+import zio.blocking.Blocking
+import zio.config.{ Config, ConfigDescriptor }
+
+object YamlConfig {
+  def fromString[A: Tag](yamlString: String, descriptor: ConfigDescriptor[A]): ZLayer[Any, Throwable, Config[A]] =
+    Config.fromConfigDescriptorM(
+      YamlConfigSource.fromString(yamlString).map(descriptor from _)
+    )
+
+  def fromPath[A: Tag](path: Path, descriptor: ConfigDescriptor[A]): ZLayer[Blocking, Throwable, Config[A]] =
+    fromFile(path.toFile, descriptor)
+
+  def fromFile[A: Tag](file: File, descriptor: ConfigDescriptor[A]): ZLayer[Blocking, Throwable, Config[A]] =
+    Config.fromConfigDescriptorM(
+      YamlConfigSource.fromFile(file).map(descriptor from _)
+    )
+}

--- a/yaml/src/main/scala/zio/config/yaml/YamlConfig.scala
+++ b/yaml/src/main/scala/zio/config/yaml/YamlConfig.scala
@@ -8,14 +8,24 @@ import zio.blocking.Blocking
 import zio.config.{ Config, ConfigDescriptor }
 
 object YamlConfig {
+
+  /**
+   * Creates a configuration layer described by the descriptor from a YAML string.
+   */
   def fromString[A: Tag](yamlString: String, descriptor: ConfigDescriptor[A]): ZLayer[Any, Throwable, Config[A]] =
     Config.fromConfigDescriptorM(
       YamlConfigSource.fromString(yamlString).map(descriptor from _)
     )
 
+  /**
+   * Creates a configuration layer described by the descriptor from a YAML file at the specified path.
+   */
   def fromPath[A: Tag](path: Path, descriptor: ConfigDescriptor[A]): ZLayer[Blocking, Throwable, Config[A]] =
     fromFile(path.toFile, descriptor)
 
+  /**
+   * Creates a configuration layer described by the descriptor from a YAML file.
+   */
   def fromFile[A: Tag](file: File, descriptor: ConfigDescriptor[A]): ZLayer[Blocking, Throwable, Config[A]] =
     Config.fromConfigDescriptorM(
       YamlConfigSource.fromFile(file).map(descriptor from _)

--- a/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
+++ b/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
@@ -2,7 +2,7 @@ package zio.config.yaml
 
 import java.io.{ File, FileInputStream }
 import java.nio.file.Path
-import java.lang.{ Boolean => JBoolean, Float => JFloat, Integer => JInteger }
+import java.lang.{ Boolean => JBoolean, Double => JDouble, Float => JFloat, Integer => JInteger, Long => JLong }
 import java.{ util => ju }
 
 import org.snakeyaml.engine.v2.api.{ Load, LoadSettings }
@@ -17,7 +17,9 @@ object YamlConfigSource {
     data match {
       case null        => PropertyTree.empty
       case t: JInteger => PropertyTree.Leaf(t.toString)
+      case t: JLong    => PropertyTree.Leaf(t.toString)
       case t: JFloat   => PropertyTree.Leaf(t.toString)
+      case t: JDouble  => PropertyTree.Leaf(t.toString)
       case t: String   => PropertyTree.Leaf(t)
       case t: JBoolean => PropertyTree.Leaf(t.toString)
       case t: ju.List[_] =>

--- a/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
+++ b/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
@@ -6,7 +6,7 @@ import java.lang.{ Boolean => JBoolean, Float => JFloat, Integer => JInteger }
 import java.{ util => ju }
 
 import org.snakeyaml.engine.v2.api.{ Load, LoadSettings }
-import zio.blocking.{ Blocking, effectBlockingInterrupt }
+import zio.blocking.{ effectBlockingInterrupt, Blocking }
 import zio.config.{ ConfigSource, LeafForSequence, PropertyTree }
 import zio.{ RIO, Task }
 
@@ -28,9 +28,15 @@ object YamlConfigSource {
         )
     }
 
+  /**
+   * Creates a configuration source from a YAML file at the specified path.
+   */
   def fromPath(path: Path): RIO[Blocking, ConfigSource] =
     fromFile(path.toFile)
 
+  /**
+   * Creates a configuration source from a YAML file.
+   */
   def fromFile(file: File): RIO[Blocking, ConfigSource] =
     effectBlockingInterrupt {
       ConfigSource.fromPropertyTree(
@@ -42,6 +48,9 @@ object YamlConfigSource {
       )
     }
 
+  /**
+   * Creates a configuration source from a YAML string.
+   */
   def fromString(yamlString: String, sourceName: String = "yaml"): Task[ConfigSource] =
     Task {
       ConfigSource.fromPropertyTree(

--- a/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
+++ b/yaml/src/main/scala/zio/config/yaml/YamlConfigSource.scala
@@ -1,0 +1,55 @@
+package zio.config.yaml
+
+import java.io.{ File, FileInputStream }
+import java.nio.file.Path
+import java.lang.{ Boolean => JBoolean, Float => JFloat, Integer => JInteger }
+import java.{ util => ju }
+
+import org.snakeyaml.engine.v2.api.{ Load, LoadSettings }
+import zio.blocking.{ Blocking, effectBlockingInterrupt }
+import zio.config.{ ConfigSource, LeafForSequence, PropertyTree }
+import zio.{ RIO, Task }
+
+import scala.collection.JavaConverters._
+
+object YamlConfigSource {
+  private[yaml] def convertYaml(data: AnyRef): PropertyTree[String, String] =
+    data match {
+      case null        => PropertyTree.empty
+      case t: JInteger => PropertyTree.Leaf(t.toString)
+      case t: JFloat   => PropertyTree.Leaf(t.toString)
+      case t: String   => PropertyTree.Leaf(t)
+      case t: JBoolean => PropertyTree.Leaf(t.toString)
+      case t: ju.List[_] =>
+        PropertyTree.Sequence(t.asInstanceOf[ju.List[AnyRef]].asScala.toList.map(convertYaml))
+      case t: ju.Map[_, _] =>
+        PropertyTree.Record(
+          t.asInstanceOf[ju.Map[String, AnyRef]].asScala.mapValues(convertYaml).toMap
+        )
+    }
+
+  def fromPath(path: Path): RIO[Blocking, ConfigSource] =
+    fromFile(path.toFile)
+
+  def fromFile(file: File): RIO[Blocking, ConfigSource] =
+    effectBlockingInterrupt {
+      ConfigSource.fromPropertyTree(
+        convertYaml(
+          new Load(LoadSettings.builder().build()).loadFromInputStream(new FileInputStream(file))
+        ),
+        file.getAbsolutePath,
+        LeafForSequence.Invalid
+      )
+    }
+
+  def fromString(yamlString: String, sourceName: String = "yaml"): Task[ConfigSource] =
+    Task {
+      ConfigSource.fromPropertyTree(
+        convertYaml(
+          new Load(LoadSettings.builder().build()).loadFromString(yamlString)
+        ),
+        sourceName,
+        LeafForSequence.Invalid
+      )
+    }
+}

--- a/yaml/src/test/scala/zio/config/yaml/YamlConfigSpec.scala
+++ b/yaml/src/test/scala/zio/config/yaml/YamlConfigSpec.scala
@@ -3,6 +3,7 @@ package zio.config.yaml
 import zio.test._
 import zio.test.Assertion._
 import zio.config.PropertyTree
+import zio.config.ConfigDescriptor
 
 object YamlConfigSpec extends DefaultRunnableSpec {
   val spec = suite("YamlConfig")(
@@ -48,6 +49,38 @@ object YamlConfigSpec extends DefaultRunnableSpec {
         .map(_.getConfigValue(List()))
         .run
         .map(assert(_)(succeeds(equalTo(expected))))
+    },
+    testM("Read a complex structure into a sealed trait") {
+      case class Child(sum: List[Sum])
+
+      sealed trait Sum         extends Product with Serializable
+      case class A(a: String)  extends Sum
+      case class B(b: Boolean) extends Sum
+
+      val descriptor =
+        ConfigDescriptor.nested("sum") {
+          ConfigDescriptor.list {
+            (ConfigDescriptor.nested("A")(ConfigDescriptor.string("a")(A.apply, A.unapply)) orElseEither
+              ConfigDescriptor.nested("B")(ConfigDescriptor.boolean("b")(B.apply, B.unapply)))
+              .xmap(_.merge, (_: Sum) match {
+                case a: A => Left(a)
+                case b: B => Right(b)
+              })
+          }
+        }(Child.apply, Child.unapply)
+
+      val result =
+        YamlConfig.fromString(
+          """|sum:
+             |- A:
+             |    a: "str"
+             |- B:
+             |    b: false""".stripMargin,
+          descriptor
+        )
+      val expected = Child(List(A("str"), B(false)))
+
+      assertM(result.build.map(_.get).run.useNow)(succeeds(equalTo(expected)))
     }
   )
 }

--- a/yaml/src/test/scala/zio/config/yaml/YamlConfigSpec.scala
+++ b/yaml/src/test/scala/zio/config/yaml/YamlConfigSpec.scala
@@ -1,0 +1,53 @@
+package zio.config.yaml
+
+import zio.test._
+import zio.test.Assertion._
+import zio.config.PropertyTree
+
+object YamlConfigSpec extends DefaultRunnableSpec {
+  val spec = suite("YamlConfig")(
+    testM("Read a complex structure") {
+      val result = YamlConfigSource.fromString(
+        """
+          |top:
+          |  child:
+          |    i: 1
+          |    b: true
+          |    s: "str"
+          |  list:
+          |  - i: 1
+          |  - b: true
+          |  - s: "str"
+          |""".stripMargin
+      )
+      val expected =
+        PropertyTree.Record(
+          Map(
+            "top" -> PropertyTree.Record(
+              Map(
+                "child" -> PropertyTree.Record(
+                  Map(
+                    "i" -> PropertyTree.Leaf("1"),
+                    "b" -> PropertyTree.Leaf("true"),
+                    "s" -> PropertyTree.Leaf("str")
+                  )
+                ),
+                "list" -> PropertyTree.Sequence(
+                  List(
+                    PropertyTree.Record(Map("i" -> PropertyTree.Leaf("1"))),
+                    PropertyTree.Record(Map("b" -> PropertyTree.Leaf("true"))),
+                    PropertyTree.Record(Map("s" -> PropertyTree.Leaf("str")))
+                  )
+                )
+              )
+            )
+          )
+        )
+
+      result
+        .map(_.getConfigValue(List()))
+        .run
+        .map(assert(_)(succeeds(equalTo(expected))))
+    }
+  )
+}


### PR DESCRIPTION
Resolves #379.

Uses snakeyaml-engine to add support for YAML 1.2 files as sources.

A possible follow-up to this would be support for multi-document yaml files.