### PR TITLE
Simplify refined module further

### DIFF
--- a/docs/refined/index.md
+++ b/docs/refined/index.md
@@ -39,7 +39,7 @@ Take a look at the below example
 
  // A list of database configs, such that size should be greater than 2.
  val databaseList: ConfigDescriptor[Refined[List[MyConfig], Size[Greater[W.`2`.T]]]] =
-   refine[List[MyConfig], Size[Greater[W.`2`.T]]](configs)
+   refine[Size[Greater[W.`2`.T]]](configs)
 ```
 
 You can also use auto derivations with refined.

--- a/examples/src/main/scala/zio/config/examples/RandomConfigGenerationSimpleExample.scala
+++ b/examples/src/main/scala/zio/config/examples/RandomConfigGenerationSimpleExample.scala
@@ -23,7 +23,7 @@ object RandomConfigGenerationSimpleExample extends App {
 
   final case class MyConfig(username: String, region: Region)
 
-  println(generateConfigJson(descriptor[MyConfig], 10).unsafeRunChunk)
+  println(generateConfigJson(descriptor[MyConfig], 1).unsafeRunChunk)
 
   // yields for example
 

--- a/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
+++ b/examples/src/main/scala/zio/config/examples/refined/RefinedReadConfig.scala
@@ -19,9 +19,9 @@ object RefinedReadConfig extends App {
   def prodConfig =
     (
       refine[String, NonEmpty]("LDAP") |@|
-        refine[Int, GreaterEqual[W.`1024`.T]](int("PORT")) |@|
+        refine[GreaterEqual[W.`1024`.T]](int("PORT")) |@|
         refine[String, NonEmpty]("DB_URL").optional |@|
-        refine[List[Long], Size[Greater[W.`2`.T]]](list("LONGS")(long))
+        refine[Size[Greater[W.`2`.T]]](list("LONGS")(long))
     )(
       RefinedProd.apply,
       RefinedProd.unapply

--- a/refined/src/main/scala/zio/config/refined/PartialRefined.scala
+++ b/refined/src/main/scala/zio/config/refined/PartialRefined.scala
@@ -1,0 +1,13 @@
+package zio.config.refined
+
+import zio.config._
+import eu.timepit.refined.api.{ RefType, Refined, Validate }
+
+private[refined] class PartialRefined[P] {
+  def apply[A](desc: ConfigDescriptor[A])(implicit validate: Validate[A, P]): ConfigDescriptor[Refined[A, P]] =
+    desc
+      .transformOrFail[Refined[A, P]](
+        RefType.applyRef[Refined[A, P]](_),
+        rf => Right(rf.value)
+      )
+}

--- a/refined/src/main/scala/zio/config/refined/package.scala
+++ b/refined/src/main/scala/zio/config/refined/package.scala
@@ -13,7 +13,7 @@ package object refined {
     implicit desc: Descriptor[A],
     validate: Validate[A, P]
   ): Descriptor[Refined[A, P]] =
-    Descriptor(refine[A, P](desc.desc))
+    Descriptor(refine[P](desc.desc))
 
   /**
    * `refine` allows us to retrieve a `refined` type from a given path.
@@ -51,16 +51,10 @@ package object refined {
    *   val configs: ConfigDescriptor[List[MyConfig]] =
    *     list("databases")(descriptor[MyConfig])
    *
-   *   val configDescriptor: ConfigDescriptor[Refined[List[MyConfig], NonEmpty]] =
-   *     refined[List[MyConfig], NonEmpty](configs)
+   *   val configDescriptor: ConfigDescriptor[Refined[List[MyConfig], Size[Greater[W.`2`.T]]]] =
+   *     refined[Size[Greater[W.`2`.T]]](configs)
    * }}}
    */
-  def refine[A, P](
-    desc: ConfigDescriptor[A]
-  )(implicit validate: Validate[A, P]): ConfigDescriptor[Refined[A, P]] =
-    desc
-      .transformOrFail[Refined[A, P]](
-        RefType.applyRef[Refined[A, P]](_),
-        rf => Right(rf.value)
-      )
+  def refine[P]: PartialRefined[P] =
+    new PartialRefined[P]
 }

--- a/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
+++ b/refined/src/test/scala/zio/config/refined/RefinedReadWriteRoundtripTest.scala
@@ -73,7 +73,7 @@ object RefinedReadWriteRoundtripTestUtils {
       refine[String, NonEmpty]("LDAP") |@|
         refine[Int, GreaterEqual[W.`1024`.T]]("PORT") |@|
         refine[String, NonEmpty]("DB_URL").optional |@|
-        refine[List[Long], Size[Greater[W.`2`.T]]](longs(n)) |@|
+        refine[Size[Greater[W.`2`.T]]](longs(n)) |@|
         refine[String, And[Trimmed, NonEmpty]]("PWD")
     )(
       RefinedProd.apply,


### PR DESCRIPTION
**Before**:

```scala
 val configs: ConfigDescriptor[List[MyConfig]] =
   list("databases")(descriptor[MyConfig])

  refine[List[MyConfig], NonEmpty](configs)


```

**After**:

```scala
 val configs: ConfigDescriptor[List[MyConfig]] =
   list("databases")(descriptor[MyConfig])

  refine[NonEmpty](configs)


```