### PR TITLE
Revert logic that handles recursion as an interim solution to get away from important bug (461) and bring back full error view

### DIFF
--- a/core/src/test/scala/zio/config/RecursiveConfigTest.scala
+++ b/core/src/test/scala/zio/config/RecursiveConfigTest.scala
@@ -1,3 +1,5 @@
+//FIXME Make Recursion work without losing the view of errors
+/*
 package zio.config
 
 import zio.test._
@@ -199,3 +201,4 @@ object RecursiveConfigTestUtils {
     case Right(value) => value
   }, "test", LeafForSequence.Invalid)
 }
+ */

--- a/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
+++ b/magnolia/src/test/scala/zio/config/magnolia/DerivationTest.scala
@@ -130,7 +130,10 @@ object DerivationTest extends DefaultRunnableSpec {
       val res = read(descriptor[B] from src)
 
       assert(res)(isRight(anything))
-    },
+    }
+
+    //FIXME Make recursion work without losing view to errors
+    /*,
     test("support recursive structures") {
       case class SimpleRec(id: Int, nested: Option[SimpleRec])
 
@@ -153,6 +156,6 @@ object DerivationTest extends DefaultRunnableSpec {
 
       val simpleRecursiveValue: SimpleRec = SimpleRec(1, Some(SimpleRec(2, None)))
       assert(read(desc from simpleTestSource))(isRight(equalTo(simpleRecursiveValue)))
-    }
+    }*/
   )
 }

--- a/shapeless/src/test/scala/zio/config/shapeless/DerivationTest.scala
+++ b/shapeless/src/test/scala/zio/config/shapeless/DerivationTest.scala
@@ -147,7 +147,10 @@ object DerivationTest extends DefaultRunnableSpec {
       val res = read(getDescriptor[B].configDescriptor from src)
 
       assert(res)(isRight(anything))
-    },
+    }
+
+    // FIXME Make recursion work without losing view to errors
+    /*,
     test("support nested lists recursive") {
       case class A(a: List[String])
       case class B(a: List[List[List[List[List[List[List[List[List[List[A]]]]]]]]]])
@@ -161,7 +164,7 @@ object DerivationTest extends DefaultRunnableSpec {
       val res = read(DeriveConfigDescriptor.descriptor[B] from src)
 
       assert(res)(isRight(anything))
-    }
+    }*/
   )
 }
 

--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
@@ -79,6 +79,8 @@ object TypesafeConfigErrorsSpec extends DefaultRunnableSpec {
         }
       val nestedConfigAutomaticExpect3 = Right(AwsConfig(Account("us-east", "jon"), None))
 
+      println(requiredZipAndOrFields(descriptor[AwsConfig]))
+
       assert(nestedConfigAutomaticResult1)(equalTo(nestedConfigAutomaticExpect1)) &&
       assert(nestedConfigAutomaticResult2)(equalTo(nestedConfigAutomaticExpect2)) &&
       assert(nestedConfigAutomaticResult3)(equalTo(nestedConfigAutomaticExpect3))
@@ -98,9 +100,8 @@ object TypesafeConfigErrorsSpec extends DefaultRunnableSpec {
         val accountConfig =
           (string("region") |@| string("accountId"))(Account.apply, Account.unapply)
         val databaseConfig = (int("port") |@| string("url"))(Database.apply, Database.unapply)
-        (nested("account")(accountConfig) |@| nested("database")(databaseConfig)
-          .orElseEither(string("database"))
-          .optional)(
+        (nested("account")(accountConfig) |@|
+          (nested("database")(databaseConfig).orElseEither(string("database"))).optional)(
           AwsConfig.apply,
           AwsConfig.unapply
         )

--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigErrorsSpec.scala
@@ -79,8 +79,6 @@ object TypesafeConfigErrorsSpec extends DefaultRunnableSpec {
         }
       val nestedConfigAutomaticExpect3 = Right(AwsConfig(Account("us-east", "jon"), None))
 
-      println(requiredZipAndOrFields(descriptor[AwsConfig]))
-
       assert(nestedConfigAutomaticResult1)(equalTo(nestedConfigAutomaticExpect1)) &&
       assert(nestedConfigAutomaticResult2)(equalTo(nestedConfigAutomaticExpect2)) &&
       assert(nestedConfigAutomaticResult3)(equalTo(nestedConfigAutomaticExpect3))

--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalBasicTest.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalBasicTest.scala
@@ -1,0 +1,76 @@
+package zio.config.typesafe
+
+import zio.test.Assertion._
+import zio.test._
+import zio.config._
+import typesafe._
+import magnolia._
+import zio.config.ReadError.Step.Key
+import zio.config.ReadError.{ Irrecoverable, MissingValue, ZipErrors }
+
+// A basic test before the set of TypesafeConfigOptionalTest
+object TypesafeConfigOptionalBasicTest extends DefaultRunnableSpec with EitherSupport {
+  val spec = suite("Optional Spec")(
+    test("Fails if any one of the required fields is missing in an optional product") {
+
+      final case class RawConfig(tableDetails: List[RawTableConfig])
+
+      final case class RawTableConfig(
+        transformOptions: Option[TransformOptions]
+      )
+
+      final case class TransformOptions(
+        header: String,
+        separator: String,
+        quoteAll: String
+      )
+
+      val string =
+        s"""
+           |      {
+           |        "transformOptions" : {
+           |            "quoteAll" : true
+           |        }
+           |      }
+           |""".stripMargin
+
+      val result: Either[ReadError[String], RawTableConfig] =
+        read(descriptor[RawTableConfig] from TypesafeConfigSource.fromHoconString(string).loadOrThrow)
+
+      val expected: Either[ReadError[String], RawTableConfig] =
+        Left(
+          Irrecoverable(
+            List(
+              ZipErrors(
+                List(
+                  ZipErrors(
+                    List(
+                      MissingValue(
+                        List(Key("transformOptions"), Key("header")),
+                        List("optional value", "value of type string"),
+                        Set()
+                      )
+                    ),
+                    Set()
+                  ),
+                  MissingValue(
+                    List(Key("transformOptions"), Key("separator")),
+                    List(
+                      "optional value",
+                      "value of " +
+                        "type string"
+                    ),
+                    Set()
+                  )
+                ),
+                Set()
+              )
+            ),
+            Set()
+          )
+        )
+
+      assert(result)(equalTo(expected))
+    }
+  )
+}

--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalBasicTest.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalBasicTest.scala
@@ -3,7 +3,6 @@ package zio.config.typesafe
 import zio.test.Assertion._
 import zio.test._
 import zio.config._
-import typesafe._
 import magnolia._
 import zio.config.ReadError.Step.Key
 import zio.config.ReadError.{ Irrecoverable, MissingValue, ZipErrors }

--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalTest.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigOptionalTest.scala
@@ -85,6 +85,26 @@ object TypesafeConfigOptionalTest
           )
         },
         test(
+          "Absence of an optional product and a required field within another optional product returns some"
+        ) {
+          val validConfig =
+            s"""
+               |      detail: {
+               |         a : 10
+               |         b : {}
+               |       }
+               |""".stripMargin
+
+          val result =
+            read(descriptor[TestCase1.CaseClass1] from getSource(validConfig))
+
+          assert(result)(
+            equalTo(
+              Right(TestCase1.CaseClass1(Some(TestCase1.CaseClass2("10", None))))
+            )
+          )
+        },
+        test(
           "Presence of all optional values in an optional product with required fields  returns failures"
         ) {
           val validConfig =
@@ -727,7 +747,10 @@ object TypesafeConfigOptionalTest
             equalTo(
               Left(
                 List(
-                  MissingValue(List(Key("a"), Key("c")), List("optional value")),
+                  MissingValue(List(Key("a"), Key("c"), Key("b2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("b1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a1")), List("optional value", "value of type string")),
                   MissingValue(List(Key("a"), Key("a"), Key("b2")), List("optional value", "value of type string")),
                   MissingValue(List(Key("a"), Key("a"), Key("a2")), List("optional value", "value of type string")),
                   MissingValue(List(Key("a"), Key("a"), Key("b1")), List("optional value", "value of type string"))
@@ -759,8 +782,14 @@ object TypesafeConfigOptionalTest
             equalTo(
               Left(
                 List(
-                  MissingValue(List(Key("a"), Key("c")), List("optional value")),
-                  MissingValue(List(Key("a"), Key("a")), List("optional value"))
+                  MissingValue(List(Key("a"), Key("c"), Key("b2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("b1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("b2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("a2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("b1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("a1")), List("optional value", "value of type string"))
                 )
               )
             )
@@ -800,8 +829,14 @@ object TypesafeConfigOptionalTest
                     List(Key("a"), Key("b"), Key("b1")),
                     List("optional value", "optional value", "value of type string")
                   ),
-                  MissingValue(List(Key("a"), Key("c")), List("optional value")),
-                  MissingValue(List(Key("a"), Key("a")), List("optional value"))
+                  MissingValue(List(Key("a"), Key("c"), Key("b2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("b1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("c"), Key("a1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("b2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("a2")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("b1")), List("optional value", "value of type string")),
+                  MissingValue(List(Key("a"), Key("a"), Key("a1")), List("optional value", "value of type string"))
                 )
               )
             )


### PR DESCRIPTION
This is a reversion of Recursion implementation, because of the introduction of a bug (https://github.com/zio/zio-config/issues/461) that turns out to be quite basic. While the recursion changes were quite amazing (and we will still be following up on this wonderful [initiative](https://github.com/zio/zio-config/compare/v1.0.0-RC27...v1.0.0-RC28)) its important that we address the immediate needs of users without making them bump into any surprising bug for basic usecases.

With this PR, the feature of full error view is back as well. Have a look at https://github.com/zio/zio-config/issues/461#issuecomment-737890541 to get a context. It is to note that the decision to trim down the view of errors to support recursion was a collective decision, however, it is now justified to bring back this feature as we are anyways commenting out recursion related tests for the time being. Going forward, let's try to stick on to this behaviour of zio-config while we solve Recursion in near future. Recursion can also come in after a 1.0 release.

In summary, we don't need users of zio-config to have tough time dealing with bugs, hence we make a new release without Recursion and separately reopen the issue of `Recursion` that will be the focus in coming days.