### PR TITLE
New variants to construct from Typesafe Config sources

### DIFF
--- a/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
+++ b/typesafe-magnolia-tests/src/test/scala/zio/config/typesafe/TypesafeConfigSpec.scala
@@ -1,5 +1,6 @@
 package zio.config.typesafe
 
+import zio.{ Has, ZIO }
 import zio.config.PropertyTree.{ Leaf, Record, Sequence }
 import zio.config.typesafe.TypesafeConfigTestSupport._
 import zio.test.Assertion._
@@ -41,6 +42,14 @@ object TypesafeConfigSpec extends DefaultRunnableSpec {
 
       assert(readComplexSource)(equalTo(expectedResult))
 
+    },
+    testM("Read a complex hocon structure produced by effect successfully") {
+      assertM(
+        TypesafeConfig
+          .fromHoconStringM(ZIO.succeed(hocon), complexDescription)
+          .build
+          .useNow
+      )(equalTo(Has(expectedResult)))
     }
   )
 }

--- a/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
+++ b/typesafe/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.typesafe.config.ConfigFactory
 import zio.config._
-import zio.{ Has, Layer, Tag, ZIO }
+import zio.{ Has, Layer, Tag, ZIO, ZLayer }
 
 object TypesafeConfig {
 
@@ -50,7 +50,7 @@ object TypesafeConfig {
     fromTypesafeConfig(ConfigFactory.parseFile(file).resolve, configDescriptor)
 
   /**
-   * Retrieve a config from `typesafe-config` from a given Hocon File.
+   * Retrieve a config from a Hocon file calculated by an effect
    *
    * A complete example usage:
    *
@@ -61,13 +61,69 @@ object TypesafeConfig {
    *   case class MyConfig(port: Int, url: String)
    *
    *   val result: Layer[ReadError[String], Has[MyConfig]] =
-   *     TypesafeConfig.fromHoconFile(new File("/path/to/xyz.hocon"), descriptor[MyConfig])
+   *     TypesafeConfig.fromHoconFileM(ZIO.succeed(new File("/path/to/xyz.hocon")), descriptor[MyConfig])
+   * }}}
+   */
+  def fromHoconFileM[R, E >: ReadError[String], A](getFile: ZIO[R, E, File], configDescriptor: ConfigDescriptor[A])(
+    implicit tag: Tag[A]
+  ): ZLayer[R, E, Has[A]] =
+    fromTypesafeConfigM(
+      getFile.flatMap { file =>
+        ZIO
+          .effect(ConfigFactory.parseFile(file).resolve)
+          .mapError(failure => ReadError.SourceError(message = failure.getMessage))
+      },
+      configDescriptor
+    )
+
+  /**
+   * Retrieve a config from a given Hocon string.
+   *
+   * A complete example usage:
+   *
+   * {{{
+   *
+   *   import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+   *
+   *   case class MyConfig(port: Int, url: String)
+   *
+   *   val configString = """port: 10, url: "http://x.y""""
+   *   val result: Layer[ReadError[String], Has[MyConfig]] =
+   *     TypesafeConfig.fromHoconString(configString, descriptor[MyConfig])
    * }}}
    */
   def fromHoconString[A](str: String, configDescriptor: ConfigDescriptor[A])(
     implicit tag: Tag[A]
   ): Layer[ReadError[String], Has[A]] =
     fromTypesafeConfig(ConfigFactory.parseString(str).resolve, configDescriptor)
+
+  /**
+   * Retrieve a config from a HOCON string value produced by an effect
+   *
+   * A complete example usage:
+   *
+   * {{{
+   *
+   *   import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+   *
+   *   case class MyConfig(port: Int, url: String)
+   *
+   *   val configString = """port: 10, url: "http://x.y""""
+   *   val result: Layer[ReadError[String], Has[MyConfig]] =
+   *     TypesafeConfig.fromHoconStringM(ZIO.succeed(configString), descriptor[MyConfig])
+   * }}}
+   */
+  def fromHoconStringM[R, E >: ReadError[String], A](getStr: ZIO[R, E, String], configDescriptor: ConfigDescriptor[A])(
+    implicit tag: Tag[A]
+  ): ZLayer[R, E, Has[A]] =
+    fromTypesafeConfigM(
+      getStr.flatMap { str =>
+        ZIO
+          .effect(ConfigFactory.parseString(str).resolve)
+          .mapError(failure => ReadError.SourceError(message = failure.getMessage))
+      },
+      configDescriptor
+    )
 
   /**
    * Retrieve a config from `com.typesafe.config.Config`
@@ -81,7 +137,7 @@ object TypesafeConfig {
    *   case class MyConfig(port: Int, url: String)
    *
    *   val result: Layer[ReadError[String], Has[MyConfig]] =
-   *     TypesafeConfig.fromHoconFile(ConfigFactory.load.resolve, descriptor[MyConfig])
+   *     TypesafeConfig.fromTypesafeConfig(ConfigFactory.load.resolve, descriptor[MyConfig])
    * }}}
    */
   def fromTypesafeConfig[A](
@@ -92,5 +148,31 @@ object TypesafeConfig {
       ZIO
         .fromEither(TypesafeConfigSource.fromTypesafeConfig(conf))
         .map(configDescriptor from _)
+    )
+
+  /**
+   * Retrieve a config from `com.typesafe.config.Config` returned by an effect
+   *
+   * A complete example usage:
+   *
+   * {{{
+   *
+   *   import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+   *
+   *   case class MyConfig(port: Int, url: String)
+   *
+   *   val result: Layer[Throwable, Has[MyConfig]] =
+   *     TypesafeConfig.fromTypesafeConfigM(ZIO.effect(ConfigFactory.load.resolve), descriptor[MyConfig])
+   * }}}
+   */
+  def fromTypesafeConfigM[R, E >: ReadError[String], A](
+    getConfig: ZIO[R, E, com.typesafe.config.Config],
+    configDescriptor: ConfigDescriptor[A]
+  )(implicit tag: Tag[A]): ZLayer[R, E, Has[A]] =
+    ZConfig.fromConfigDescriptorM(
+      for {
+        config    <- getConfig
+        rawConfig <- ZIO.fromEither(TypesafeConfigSource.fromTypesafeConfig(config))
+      } yield configDescriptor from rawConfig
     )
 }


### PR DESCRIPTION
It is common to determine the config location runtime with some effectful operation such as checking environment variables to determine the execution environment where the application runs. This was very inconvenient because all the layer constructors in `TypesafeConfig` accept either a `File`, a `String` or an already loaded `Config` value.

This PR adds variants to the above mentioned functions that allows to pass an effect to produce the input. 

Alternatives could be:
- Variants that produce layers where the `File`/`String`/`Config` is the input of the layer
- `ZManaged` variants that can be combined and converted to layer by the user

I think my version is the simplest and most straightforward to use for this case.