### PR TITLE
use zio.system.System to load System properties

### DIFF
--- a/core/src/main/scala/zio/config/ConfigStringModule.scala
+++ b/core/src/main/scala/zio/config/ConfigStringModule.scala
@@ -858,7 +858,7 @@ trait ConfigStringModule extends ConfigModule with ConfigSourceStringModule {
       valueDelimiter: Option[Char] = None
     )(implicit tag: Tag[A]): ZLayer[System, ReadError[String], Has[A]] =
       fromConfigDescriptorM(
-        ConfigSource.fromSystemProperties(keyDelimiter, valueDelimiter).map(configDescriptor from _)
+        ConfigSource.fromSystemProps(keyDelimiter, valueDelimiter).map(configDescriptor from _)
       )
 
     private[config] def fromConfigDescriptor[A](


### PR DESCRIPTION
This PR makes it possible to set `system properties` using `TestSystem`, like it is possible for `env variables`

Also it fixes following which is misleading to the user:
`ZConfig.fromSystemProperties` return type is `ZLayer[System, ReadError[String], Has[A]]` which makes user think that they can use `TestSystem` or their own `System` from where to load system properties from when they wire their app together, but it is a lie as it uses internally `ConfigSource.fromSystemProperties` which has a return type of  `UIO[ConfigSource]` and gets properties from `java.lang.System.getProperties`