### PR TITLE
Use Scala 2.13 by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val root =
   project
     .in(file("."))
     .settings(skip in publish := true)
-    .aggregate(scala211projects: _*)
+    .aggregate(scala213projects: _*)
 
 lazy val `root2-11` =
   project


### PR DESCRIPTION
Attempt at hot-fixing https://github.com/zio/zio-config/issues/510
More robust solutions needs to be found -- `root` should aggregate _all_ projects

/cc @mijicd 