### PR TITLE
refactor zip case for write

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,6 @@ lazy val zioConfig = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"                %% "zio"                     % zioVersion,
-      "dev.zio"                 %% "zio-prelude"            % "1.0.0-RC6",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
       "dev.zio"                %% "zio-test"                % zioVersion % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -167,6 +167,7 @@ lazy val zioConfig = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"                %% "zio"                     % zioVersion,
+      "dev.zio"                 %% "zio-prelude"            % "1.0.0-RC6",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
       "dev.zio"                %% "zio-test"                % zioVersion % Test
     ),

--- a/core/shared/src/main/scala/zio/config/PropertyTree.scala
+++ b/core/shared/src/main/scala/zio/config/PropertyTree.scala
@@ -1,6 +1,7 @@
 package zio.config
 
 import com.github.ghik.silencer.silent
+import zio.prelude.NonEmptyList
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Nil
@@ -116,12 +117,12 @@ sealed trait PropertyTree[+K, +V] { self =>
    * @param that
    * @return
    */
-  final def merge[K1 >: K, V1 >: V](that: PropertyTree[K1, V1]): List[PropertyTree[K1, V1]] =
+  final def merge[K1 >: K, V1 >: V](that: PropertyTree[K1, V1]): NonEmptyList[PropertyTree[K1, V1]] =
     (self, that) match {
-      case (Sequence(l), Sequence(r))           => singleton(Sequence(l ++ r))
+      case (Sequence(l), Sequence(r))           => NonEmptyList(Sequence(l ++ r))
       case (l: Record[K, V], r: Record[K1, V1]) =>
         (l.value.keySet ++ r.value.keySet)
-          .foldLeft(List[Map[K1, PropertyTree[K1, V1]]](Map.empty)) { case (acc, k) =>
+          .foldLeft(NonEmptyList[Map[K1, PropertyTree[K1, V1]]](Map.empty)) { case (acc, k) =>
             (l.value.get(k.asInstanceOf[K]), r.value.get(k)) match {
               case (None, None)       => acc
               case (Some(l), Some(r)) =>
@@ -131,9 +132,9 @@ sealed trait PropertyTree[+K, +V] { self =>
             }
           }
           .map(v => PropertyTree.Record(v))
-      case (left, right) if left.isEmpty        => singleton(right)
-      case (left, right) if right.isEmpty       => singleton(left)
-      case (l, r)                               => l :: r :: Nil
+      case (left, right) if left.isEmpty        => NonEmptyList(right)
+      case (left, right) if right.isEmpty       => NonEmptyList(left)
+      case (l, r)                               => NonEmptyList(l, r)
     }
 
   final def nonEmpty: Boolean = !isEmpty

--- a/core/shared/src/main/scala/zio/config/PropertyTree.scala
+++ b/core/shared/src/main/scala/zio/config/PropertyTree.scala
@@ -1,7 +1,7 @@
 package zio.config
 
 import com.github.ghik.silencer.silent
-import zio.prelude.NonEmptyList
+import zio.NonEmptyChunk
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Nil
@@ -117,12 +117,12 @@ sealed trait PropertyTree[+K, +V] { self =>
    * @param that
    * @return
    */
-  final def merge[K1 >: K, V1 >: V](that: PropertyTree[K1, V1]): NonEmptyList[PropertyTree[K1, V1]] =
+  final def merge[K1 >: K, V1 >: V](that: PropertyTree[K1, V1]): NonEmptyChunk[PropertyTree[K1, V1]] =
     (self, that) match {
-      case (Sequence(l), Sequence(r))           => NonEmptyList(Sequence(l ++ r))
+      case (Sequence(l), Sequence(r))           => NonEmptyChunk(Sequence(l ++ r))
       case (l: Record[K, V], r: Record[K1, V1]) =>
         (l.value.keySet ++ r.value.keySet)
-          .foldLeft(NonEmptyList[Map[K1, PropertyTree[K1, V1]]](Map.empty)) { case (acc, k) =>
+          .foldLeft(NonEmptyChunk[Map[K1, PropertyTree[K1, V1]]](Map.empty)) { case (acc, k) =>
             (l.value.get(k.asInstanceOf[K]), r.value.get(k)) match {
               case (None, None)       => acc
               case (Some(l), Some(r)) =>
@@ -132,9 +132,9 @@ sealed trait PropertyTree[+K, +V] { self =>
             }
           }
           .map(v => PropertyTree.Record(v))
-      case (left, right) if left.isEmpty        => NonEmptyList(right)
-      case (left, right) if right.isEmpty       => NonEmptyList(left)
-      case (l, r)                               => NonEmptyList(l, r)
+      case (left, right) if left.isEmpty        => NonEmptyChunk(right)
+      case (left, right) if right.isEmpty       => NonEmptyChunk(left)
+      case (l, r)                               => NonEmptyChunk(l, r)
     }
 
   final def nonEmpty: Boolean = !isEmpty

--- a/core/shared/src/main/scala/zio/config/WriteModule.scala
+++ b/core/shared/src/main/scala/zio/config/WriteModule.scala
@@ -69,11 +69,9 @@ private[config] trait WriteModule extends ConfigDescriptorModule {
           val rightResult = go(cd.right, tuple._2)
 
           for {
-            left   <- leftResult
-            right  <- rightResult
-            merged  = left.merge(right)
-            result <- merged.headOption.toRight("Failed to write the config back to property tree, at zip node")
-          } yield result
+            left  <- leftResult
+            right <- rightResult
+          } yield left.merge(right).head
       }
     go(config, a)
   }


### PR DESCRIPTION
`write` should not produce new errors on `Zip` as the `merge` method essentially returns a `NonEmptyList`.

On another note, `TransformOrFail` is the only other case that produces new errors. In general, I don't think `write` should fail but  `TransformOrFail` allows for failures for transformation in both directions.