### PR TITLE
Added links for the documentation for newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Using a single definition of configuration requirements, which can be derived au
  * Automatically generate documentation so devs / devops know how to configure the application
  * Generate a report that shows where each piece of configuration data came from
 
-Please find more details in the [website](https://zio.github.io/zio-config/).
+Please find more details in the [website](https://zio.github.io/zio-config/). The website is currently for the zio-config version 1.x only. For newer versions, please check the markdown files in `docs` directory here in GitHub.
+For example, the docs for 3.x is available [here](https://github.com/yadavan88/zio-config/tree/master/docs). The updated website will be published soon for the newer versions.
 
 If you are only interested in automatic derviation of configuration, find the details [here](https://zio.github.io/zio-config/docs/automatic/automatic_index).
 

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -7,6 +7,8 @@ title:  "Quick Start"
 The library aims to have a powerful & purely functional, yet a thin interface to access configuration information inside an application.
 There are many examples in [here](https://github.com/zio/zio-config/tree/master/examples/src/main/scala/zio/config/examples) straight away as well.
 
+__Note that this documentation is for 1.x series. For newer versions, please refer to [docs](https://github.com/zio/zio-config/tree/master/docs) section in GitHub.__
+
 ## Adding dependency
 
 If you are using sbt:


### PR DESCRIPTION
The website contains the samples for 1.x versions only.
Modified the website and readme to provide the links for the latest documentation. 

Based on: https://github.com/zio/zio-config/issues/851