### PR TITLE
Suspend the creation and loading of Config in ZIO

### DIFF
--- a/typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
+++ b/typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfig.scala
@@ -1,6 +1,5 @@
 package zio.config.typesafe
 
-import com.typesafe.config.ConfigFactory
 import zio._
 import zio.config._
 
@@ -27,7 +26,9 @@ object TypesafeConfig {
   def fromResourcePath[A](
     configDescriptor: ConfigDescriptor[A]
   )(implicit tag: Tag[A]): Layer[ReadError[String], A] =
-    fromTypesafeConfig(ConfigFactory.load.resolve, configDescriptor)
+    ZConfig.fromConfigDescriptor(
+      configDescriptor from TypesafeConfigSource.fromResourcePath
+    )
 
   /**
    * Retrieve your config from a HOCON file
@@ -113,10 +114,10 @@ object TypesafeConfig {
    * }}}
    */
   def fromTypesafeConfig[A](
-    conf: => com.typesafe.config.Config,
+    conf: ZIO[Any, Throwable, com.typesafe.config.Config],
     configDescriptor: ConfigDescriptor[A]
   )(implicit tag: Tag[A]): Layer[ReadError[String], A] =
     ZConfig.fromConfigDescriptor(
-      configDescriptor from TypesafeConfigSource.fromTypesafeConfig(ZIO.succeed(conf))
+      configDescriptor from TypesafeConfigSource.fromTypesafeConfig(conf)
     )
 }

--- a/typesafe/shared/src/main/scala/zio/config/typesafe/package.scala
+++ b/typesafe/shared/src/main/scala/zio/config/typesafe/package.scala
@@ -28,7 +28,7 @@ package object typesafe {
       TypesafeConfig.fromHoconString(hoconString, configDescriptor)
 
     def fromTypesafeConfig[A](
-      conf: => com.typesafe.config.Config,
+      conf: ZIO[Any, Throwable, com.typesafe.config.Config],
       configDescriptor: ConfigDescriptor[A]
     )(implicit tag: Tag[A]): Layer[ReadError[String], A] =
       TypesafeConfig.fromTypesafeConfig(conf, configDescriptor)


### PR DESCRIPTION
This also bring the `TypesafeConfig`'s API in line with `TypesafeConfigSource` and thus makes the whole API more regular.