### PR TITLE
Update to zio-aws 5.19.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ addCommandAlias(
 )
 
 val awsVersion        = "1.12.360"
-val zioAwsVersion     = "5.17.295.13"
+val zioAwsVersion     = "5.19.8.1"
 val zioVersion        = "2.0.5"
 val magnoliaVersion   = "0.17.0"
 val refinedVersion    = "0.10.1"


### PR DESCRIPTION
This is breaking binary compatibility because it updates zio-prelude from RC15 to RC16