### PR TITLE
Add `zio.Duration` for Scala 2 derivation

### DIFF
--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
@@ -41,6 +41,7 @@ object DeriveConfig {
   implicit val implicitDoubleDesc: DeriveConfig[Double]               = DeriveConfig(double)
   implicit val implicitBigDecimalDesc: DeriveConfig[BigDecimal]       = DeriveConfig(bigDecimal)
   implicit val implicitUriDesc: DeriveConfig[URI]                     = DeriveConfig(uri)
+  implicit val implicitDurationDesc: DeriveConfig[zio.Duration]       = DeriveConfig(duration)
   implicit val implicitLocalDateDesc: DeriveConfig[LocalDate]         = DeriveConfig(localDate)
   implicit val implicitLocalTimeDesc: DeriveConfig[LocalTime]         = DeriveConfig(localTime)
   implicit val implicitLocalDateTimeDesc: DeriveConfig[LocalDateTime] = DeriveConfig(localDateTime)


### PR DESCRIPTION
It exists only for Scala 3.