### PR TITLE
Remove silencer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.16', '2.13.8', '3.2.2']
+        scala: ['2.12.18', '2.13.12', '3.3.1']
         platform: ['JS', 'JVM', 'Native']
     steps:
       - name: Checkout current branch

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,6 @@ lazy val zioConfigAws = crossProject(JVMPlatform)
   .dependsOn(zioConfig % "compile->compile;test->test")
 
 lazy val zioConfigAwsJVM = zioConfigAws.jvm
-  .settings(dottySettings)
 
 lazy val zioConfigZioAws = crossProject(JVMPlatform)
   .in(file("zio-aws"))
@@ -195,7 +194,6 @@ lazy val zioConfigZioAws = crossProject(JVMPlatform)
   .dependsOn(zioConfig % "compile->compile;test->test")
 
 lazy val zioConfigZioAwsJVM = zioConfigZioAws.jvm
-  .settings(dottySettings)
 
 lazy val zioConfigRefined = crossProject(JVMPlatform)
   .in(file("refined"))
@@ -271,7 +269,6 @@ lazy val zioConfigDerivation = crossProject(JVMPlatform)
   .dependsOn(zioConfig)
 
 lazy val zioConfigDerivationJVM = zioConfigDerivation.jvm
-  .settings(dottySettings)
 
 lazy val zioConfigMagnolia = crossProject(JVMPlatform)
   .in(file("magnolia"))
@@ -313,7 +310,6 @@ lazy val zioConfigTypesafe = crossProject(JVMPlatform)
   .dependsOn(zioConfig % "compile->compile;test->test")
 
 lazy val zioConfigTypesafeJVM = zioConfigTypesafe.jvm
-  .settings(dottySettings)
 
 lazy val zioConfigYaml = crossProject(JVMPlatform)
   .in(file("yaml"))

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ inThisBuild(
 
 addCommandAlias("fmt", "; scalafmtSbt; scalafmt; test:scalafmt")
 addCommandAlias("fix", "; all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll")
-addCommandAlias("compileAll", "; ++2.12.16; root2-12/compile; ++2.13.8!; root2-13/compile")
-addCommandAlias("testAll", "; ++2.12.16; root2-12/test; ++2.13.8!; root2-13/test")
+addCommandAlias("compileAll", "; ++2.12.18; root2-12/compile; ++2.13.12!; root2-13/compile")
+addCommandAlias("testAll", "; ++2.12.18; root2-12/test; ++2.13.12!; root2-13/test")
 addCommandAlias(
   "testJS",
   ";zioConfigJS/test"

--- a/core/shared/src/main/scala-2.x/zio/config/TupleConversion.scala
+++ b/core/shared/src/main/scala-2.x/zio/config/TupleConversion.scala
@@ -14,6 +14,11 @@ object TupleConversion        {
     c: whitebox.Context
   ): c.Expr[TupleConversion[P, T]] = {
     import c.universe._
+    implicitly[c.WeakTypeTag[T]]
+    // silence unused parameter warning.
+    // we can't use a @nowarn annotation because the WeakTypeTag is needed
+    // on scala 2.12 and we would therefore get a
+    // "@nowarn annotation does not suppress any warnings" error on that version
     val prodTpe    = c.weakTypeOf[P]
     if (
       !prodTpe.typeSymbol.isClass ||

--- a/examples/shared/src/main/scala/zio/config/examples/SimpleReadConfigExample.scala
+++ b/examples/shared/src/main/scala/zio/config/examples/SimpleReadConfigExample.scala
@@ -20,7 +20,7 @@ object ReadConfig extends ZIOAppDefault {
 
   def run: URIO[Any, ExitCode] =
     read(Prod.prodConfig from ConfigProvider.fromMap(Map("LDAP" -> "ldap", "PORT" -> "1999", "DB_URL" -> "ddd")))
-      .foldZIO(
+      .foldZIO[Any, Throwable, Any](
         failure => Console.printLine(failure.toString),
         value => Console.printLine(value.toString)
       )

--- a/examples/shared/src/main/scala/zio/config/examples/autoderivation/AutoDerivationCustomKeys.scala
+++ b/examples/shared/src/main/scala/zio/config/examples/autoderivation/AutoDerivationCustomKeys.scala
@@ -1,6 +1,5 @@
 package zio.config.examples.autoderivation
 
-import com.github.ghik.silencer.silent
 import zio.config._
 import zio.config.examples.typesafe.EitherImpureOps
 import zio.config.magnolia.deriveConfig
@@ -9,7 +8,6 @@ import zio.{Config, IO}
 
 import examples._
 
-@silent("deprecated")
 object AutoDerivationCustomKeys extends App with EitherImpureOps {
   final case class MyConfig(accountId: String, awsRegion: String)
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -26,8 +26,6 @@ object BuildHelper {
   val Scala213: String                   = versions("2.13")
   val ScalaDotty: String                 = versions("3")
 
-  val SilencerVersion = "1.7.12"
-
   private val stdOptions = Seq(
     "-deprecation",
     "-encoding",
@@ -213,13 +211,9 @@ object BuildHelper {
     scalacOptions                          := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= {
       if (scalaVersion.value == ScalaDotty)
-        Seq(
-          "com.github.ghik" % s"silencer-lib_$Scala213" % SilencerVersion % Provided
-        )
+        Seq.empty
       else
         Seq(
-          "com.github.ghik" % "silencer-lib"            % SilencerVersion % Provided cross CrossVersion.full,
-          compilerPlugin("com.github.ghik" % "silencer-plugin" % SilencerVersion cross CrossVersion.full),
           compilerPlugin("org.typelevel"  %% "kind-projector"  % "0.13.2" cross CrossVersion.full)
         )
     },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # We should stick to v1.6.2 for now, as newer versions of sbt breaks the publishing step in Github Action.
-sbt.version = 1.6.2
+sbt.version = 1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                     % "1.5.3")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.10.1")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"                  % "0.11.1")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"                    % "0.4.3")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"                % "1.5.10")
@@ -10,7 +10,7 @@ addSbtPlugin("de.heikoseeberger"                 % "sbt-header"                 
 addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.2.0")
 addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.12.0")
-addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.5")
+addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.16")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.3.7")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.6")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
@@ -19,4 +19,4 @@ addSbtPlugin("dev.zio"                           % "zio-sbt-website"            
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.6"
 
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")

--- a/refined/shared/src/main/scala/zio/config/refined/package.scala
+++ b/refined/shared/src/main/scala/zio/config/refined/package.scala
@@ -1,6 +1,5 @@
 package zio.config
 
-import com.github.ghik.silencer.silent
 import eu.timepit.refined.api.{RefType, Refined, Validate}
 import zio.Config
 import zio.config.magnolia.DeriveConfig
@@ -10,7 +9,6 @@ package object refined {
   /**
    * FIXME Automatically derive instances of Descriptor for any refined types
    */
-  @silent("deprecated")
   implicit def deriveRefinedDescriptor[A, P](implicit
     desc: DeriveConfig[A],
     validate: Validate[A, P]
@@ -29,7 +27,6 @@ package object refined {
    *     refined[String, Uuid]("ID")
    * }}}
    */
-  @silent("deprecated")
   def refine[A, P](path: String)(implicit
     desc: DeriveConfig[A],
     validate: Validate[A, P]

--- a/typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfigProvider.scala
+++ b/typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfigProvider.scala
@@ -1,19 +1,14 @@
 package zio.config.typesafe
 
-import com.github.ghik.silencer.silent
 import com.typesafe.config._
 import zio.config.IndexedFlat.{ConfigPath, KeyComponent}
-import zio.config._
 import zio.{Chunk, ConfigProvider}
 
 import java.io.File
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-@silent("Unused import")
 object TypesafeConfigProvider {
-
-  import VersionSpecificSupport._
 
   /**
    * Retrieve a `ConfigProvider` from `typesafe-config` from a given file in resource classpath.

--- a/xml/shared/src/main/scala/zio/config/xml/experimental/XmlConfigProvider.scala
+++ b/xml/shared/src/main/scala/zio/config/xml/experimental/XmlConfigProvider.scala
@@ -1,10 +1,8 @@
 package zio.config.xml.experimental
 
-import com.github.ghik.silencer.silent
 import zio.ConfigProvider
 import zio.config.IndexedFlat.ConfigPath
 
-@silent("Unused import")
 object XmlConfigProvider {
 
   /**

--- a/yaml/shared/src/main/scala/zio/config/yaml/YamlConfigProvider.scala
+++ b/yaml/shared/src/main/scala/zio/config/yaml/YamlConfigProvider.scala
@@ -1,6 +1,6 @@
 package zio.config.yaml
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
 import zio.config._
 import zio.config.syntax.IndexKey
@@ -13,7 +13,7 @@ import java.nio.file.Path
 import java.{util => ju}
 import scala.jdk.CollectionConverters._
 
-@silent("Unused import")
+@nowarn("cat=unused-imports")
 object YamlConfigProvider {
 
   import scala.collection.compat._


### PR DESCRIPTION
Whenever I try to publish a library that depends on zio-config-typesafe, I get an error:
```
[error] -- Error: typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfigProvider.scala:13:0 
[error] undefined: new com.github.ghik.silencer.silent # -1: TermRef(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class ghik)),object silencer),silent),<init>) at readTasty
[error] one error found
```
This seems to be caused by the `Provided` dependency on silencer-lib and is a constant hassle. Silencer is obsolete since this functionality was incorporated into the upstream Scala compiler in the form of the `@nowarn` annotation. I therefore think it makes sense to get rid of it. 