### PR TITLE
Make it possible to use `derives Config` syntax in Scala 3

### DIFF
--- a/docs/automatic-derivation-of-config.md
+++ b/docs/automatic-derivation-of-config.md
@@ -322,6 +322,25 @@ In this case, the config should be
 }
 ```
 
+### Config derivation via `derives` keyword
+
+Scala 3 has introduced `derives` keyword to derive typeclasses without the need of explicitely declaring the implicit / given.
+This syntax can be enabled for `zio.Config` by importing `zio.config.magnolia.*` and then using the `derives` keyword on the type that needs to be derived:
+
+```scala 3
+import zio.config.magnolia.*
+import zio.{Config, ZIO}
+
+sealed trait A
+case class B(x: String) extends A
+case class C(y: String) extends A
+
+case class MyConfig(a: A) derives Config
+
+// And then simply summon the `Config[MyConfig]` instance as you would normally:
+val cfg = ZIO.config[MyConfig]
+```
+
 ### No guaranteed behavior for scala-3 enum yet
 With the current release, there is no guaranteed support of scala-3 enum. 
 Use `sealed trait` and `case class` pattern.

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/package.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/package.scala
@@ -1,9 +1,9 @@
 package zio.config
 
-import zio.ConfigProvider
-
-import zio.Config
+import zio.{Config, ConfigProvider}
 import zio.IO
+
+import scala.deriving.Mirror
 
 package object magnolia {
   def deriveConfig[A](implicit ev: DeriveConfig[A]) =
@@ -26,4 +26,12 @@ package object magnolia {
     def autoLoad[A: DeriveConfig]: IO[Config.Error, A] =
       configProvider.load(DeriveConfig[A].desc)
   }
+
+  /**
+   * Enables derivation of Config via the `derives Config` syntax
+   */
+  extension (? : Config.type) {
+    inline def derived[A](using Mirror.Of[A]): Config[A] = DeriveConfig.derived[A].desc
+  }
+
 }

--- a/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/AutomaticConfigSpec.scala
+++ b/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/AutomaticConfigSpec.scala
@@ -1,6 +1,6 @@
 package zio.config.magnolia
 
-import zio.ConfigProvider
+import zio.{Config, ConfigProvider}
 import zio.config._
 import zio.test.Assertion._
 import zio.test._
@@ -19,6 +19,14 @@ object AutomaticConfigSpec extends ZIOSpecDefault {
 
           val source =
             ConfigProvider.fromMap(environment)
+
+          assertZIO(source.load(configDesc).either)(isRight)
+        }
+      },
+      test("derives syntax spec") {
+        check(genEnvironment) { environment =>
+          val configDesc = summon[Config[MyConfigDerived]]
+          val source     = ConfigProvider.fromMap(environment)
 
           assertZIO(source.load(configDesc).either)(isRight)
         }
@@ -62,6 +70,22 @@ object AutomaticConfigTestUtils {
     lastVisited: LocalDateTime,
     id: UUID
   )
+
+  final case class MyConfigDerived(
+    aws: Aws,
+    cost: Price,
+    dburl: DbUrl,
+    port: Int,
+    amount: Option[Long],
+    quantity: Either[Long, String],
+    default: Int = 1,
+    anotherDefault: Boolean = true,
+    descriptions: List[String],
+    created: LocalDate,
+    updated: LocalTime,
+    lastVisited: LocalDateTime,
+    id: UUID
+  ) derives Config
 
   private val genPriceDescription             = Gen.const(Description("some description"))
   private val genCurrency: Gen[Any, Currency] = Gen.double(10.0, 20.0).map(Currency.apply)


### PR DESCRIPTION
See related issue in ZIO: https://github.com/zio/zio/issues/9268.

This PR allows essentially allows users to use `derives Config` syntax on Product and Sum types when the following import is present:

```scala
import zio.config.magnolia.*
```