### PR TITLE
Reduce amount of generated code when deriving `Config`s in Scala 3

### DIFF
--- a/core/shared/src/main/scala-3.x/zio/config/TupleConversion.scala
+++ b/core/shared/src/main/scala-3.x/zio/config/TupleConversion.scala
@@ -10,7 +10,7 @@ trait TupleConversion[A, B] {
 object TupleConversion extends ImplicitTupleConversion
 
 trait ImplicitTupleConversion {
-  inline given autoTupleConversion[Prod <: Product](using
+  given autoTupleConversion[Prod <: Product](using
     m: Mirror.ProductOf[Prod]
   ): TupleConversion[Prod, m.MirroredElemTypes] =
     new TupleConversion[Prod, m.MirroredElemTypes] {
@@ -20,12 +20,11 @@ trait ImplicitTupleConversion {
 
   inline given autoTupleConversion1[Prod <: Product, A](using
     c: TupleConversion[Prod, Tuple1[A]]
-  ): TupleConversion[Prod, A] =
-    new TupleConversion[Prod, A] {
-      def to(a: Prod): A   = {
-        val Tuple1(v) = c.to(a)
-        v
-      }
-      def from(b: A): Prod = c.from(Tuple1(b))
+  ): TupleConversion[Prod, A] with {
+    def to(a: Prod): A   = {
+      val Tuple1(v) = c.to(a)
+      v
     }
+    def from(b: A): Prod = c.from(Tuple1(b))
+  }
 }

--- a/core/shared/src/main/scala/zio/config/package.scala
+++ b/core/shared/src/main/scala/zio/config/package.scala
@@ -1,10 +1,8 @@
 package zio
 
-import zio.config.syntax.ConfigSyntax
-
 package object config
     extends KeyConversionFunctions
-    with ConfigSyntax
+    with syntax.ConfigSyntax
     with ImplicitTupleConversion
     with ConfigDocsModule {
 

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -111,29 +111,28 @@ object DeriveConfig {
   given mapDesc[A](using ev: DeriveConfig[A]): DeriveConfig[Map[String, A]] =
     DeriveConfig.from(table(ev.desc))
 
-  inline def summonDeriveConfigForCoProduct[T <: Tuple](
-    inline acc: List[DeriveConfig[Any]] = Nil
-  ): List[DeriveConfig[Any]] =
-    inline erasedValue[T] match
-      case _: EmptyTuple => acc
+  inline def summonDeriveConfigForCoProduct[T <: Tuple]: List[DeriveConfig[Any]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
       case _: (t *: ts)  =>
-        summonDeriveConfigForCoProduct[ts] {
-          val desc = summonInline[DeriveConfig[t]]
-          DeriveConfig[Any](
-            desc.desc,
-            desc.metadata
-          ) :: acc
-        }
+        val desc = summonInline[DeriveConfig[t]]
+        DeriveConfig[Any](
+          desc.desc,
+          desc.metadata
+        ) :: summonDeriveConfigForCoProduct[ts]
+    }
 
-  inline def summonDeriveConfigAll[T <: Tuple](inline acc: List[DeriveConfig[_]] = Nil): List[DeriveConfig[_]] =
-    inline erasedValue[T] match
-      case _: EmptyTuple => acc
-      case _: (t *: ts)  => summonDeriveConfigAll[ts](summonInline[DeriveConfig[t]] :: acc)
+  inline def summonDeriveConfigAll[T <: Tuple]: List[DeriveConfig[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[DeriveConfig[t]] :: summonDeriveConfigAll[ts]
+    }
 
-  inline def labelsOf[T <: Tuple](inline acc: List[String] = Nil): List[String] =
-    inline erasedValue[T] match
-      case _: EmptyTuple => acc
-      case _: (t *: ts)  => labelsOf[ts](constValue[t].toString :: acc)
+  inline def labelsOf[T <: Tuple]: List[String] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => constValue[t].toString :: labelsOf[ts]
+    }
 
   inline def customNamesOf[T]: List[String] =
     inline Macros.nameOf[T] match {
@@ -158,7 +157,7 @@ object DeriveConfig {
             typeDiscriminator = Macros.discriminator[T].headOption.map(_.keyName)
           )
 
-        val subClassDescriptions = summonDeriveConfigForCoProduct[m.MirroredElemTypes]()
+        val subClassDescriptions = summonDeriveConfigForCoProduct[m.MirroredElemTypes]
         val desc                 = mergeAllProducts(subClassDescriptions.map(castTo[DeriveConfig[T]]), coproductName.typeDiscriminator)
 
         DeriveConfig.from(tryAllKeys(desc.desc, None, coproductName.alternativeNames))
@@ -171,7 +170,7 @@ object DeriveConfig {
             descriptions = Macros.documentationOf[T].map(_.describe)
           )
 
-        val originalFieldNamesList = labelsOf[m.MirroredElemLabels]()
+        val originalFieldNamesList = labelsOf[m.MirroredElemLabels]
         val customFieldNameMap     = customFieldNamesOf[T]
         val documentations         = Macros.fieldDocumentationOf[T].toMap
         val fieldNames             = mapOriginalNames(originalFieldNamesList, documentations, customFieldNameMap)
@@ -261,14 +260,13 @@ object DeriveConfig {
   ): DeriveConfig[T] =
     mergeAllFields[T](allDescs, productName, fieldNames, f)
 
-  @targetName("mergeAllFieldsV2")
   def mergeAllFields[T](
     allDescs: => List[DeriveConfig[_]],
     productName: ProductName,
     fieldNames: List[FieldName],
     f: List[Any] => T
   ): DeriveConfig[T] =
-    if fieldNames.isEmpty then // if there are no fields in the product then the value is the name of the product itself
+    if fieldNames.isEmpty then { // if there are no fields in the product then the value is the name of the product itself
       val tryAllPaths =
         (productName.originalName :: productName.alternativeNames)
           .map(n => zio.Config.constant(n))
@@ -278,7 +276,7 @@ object DeriveConfig {
         tryAllPaths.map[T](_ => f(Nil)),
         Some(Metadata.Object[T](productName, f(Nil))) // We propogate the info that product was actually an object
       )
-    else
+    } else {
       val listOfDesc =
         fieldNames.zip(allDescs).map { case (fieldName, desc) =>
           val fieldDesc = tryAllKeys(desc.desc, Some(fieldName.originalName), fieldName.alternativeNames)
@@ -289,6 +287,7 @@ object DeriveConfig {
         Config.collectAll(listOfDesc.head, listOfDesc.tail*)
 
       DeriveConfig(descOfList.map(f), Some(Metadata.Product(productName, fieldNames)))
+    }
 
   def tryAllKeys[A](
     desc: Config[A],

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -1,21 +1,17 @@
 package zio.config.magnolia
 
-import zio.config._
-import zio.NonEmptyChunk
+import zio.Config.*
+import zio.config.*
+import zio.config.derivation.*
+import zio.config.magnolia.DeriveConfig.*
+import zio.{Chunk, Config, LogLevel}
 
-import java.io.File
-import java.net.{URI, URL}
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime}
+import java.net.URI
+import java.time.{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, *}
 import java.util.UUID
-import scala.concurrent.duration.{Duration => ScalaDuration}
-import scala.deriving._
-import scala.compiletime.{constValue, constValueTuple, erasedValue, summonFrom, summonInline}
-import scala.quoted
-import scala.util.Try
-import DeriveConfig._
-import zio.{Chunk, Config, ConfigProvider, LogLevel}, Config._
-import zio.config.syntax._
-import zio.config.derivation._
+import scala.annotation.{targetName, threadUnsafe}
+import scala.compiletime.*
+import scala.deriving.*
 
 final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
   def ??(description: String): DeriveConfig[A] =
@@ -115,36 +111,45 @@ object DeriveConfig {
   given mapDesc[A](using ev: DeriveConfig[A]): DeriveConfig[Map[String, A]] =
     DeriveConfig.from(table(ev.desc))
 
-  inline def summonDeriveConfigForCoProduct[T <: Tuple]: List[DeriveConfig[Any]] =
+  inline def summonDeriveConfigForCoProduct[T <: Tuple](
+    inline acc: List[DeriveConfig[Any]] = Nil
+  ): List[DeriveConfig[Any]] =
     inline erasedValue[T] match
-      case _: EmptyTuple => Nil
+      case _: EmptyTuple => acc
       case _: (t *: ts)  =>
-        val desc = summonInline[DeriveConfig[t]]
-        DeriveConfig[Any](
-          desc.desc,
-          desc.metadata
-        ) :: summonDeriveConfigForCoProduct[ts]
+        summonDeriveConfigForCoProduct[ts] {
+          val desc = summonInline[DeriveConfig[t]]
+          DeriveConfig[Any](
+            desc.desc,
+            desc.metadata
+          ) :: acc
+        }
 
-  inline def summonDeriveConfigAll[T <: Tuple]: List[DeriveConfig[_]] =
+  inline def summonDeriveConfigAll[T <: Tuple](inline acc: List[DeriveConfig[_]] = Nil): List[DeriveConfig[_]] =
     inline erasedValue[T] match
-      case _: EmptyTuple => Nil
-      case _: (t *: ts)  =>
-        summonInline[DeriveConfig[t]] :: summonDeriveConfigAll[ts]
+      case _: EmptyTuple => acc
+      case _: (t *: ts)  => summonDeriveConfigAll[ts](summonInline[DeriveConfig[t]] :: acc)
 
-  inline def labelsOf[T <: Tuple]: List[String] =
+  inline def labelsOf[T <: Tuple](inline acc: List[String] = Nil): List[String] =
     inline erasedValue[T] match
-      case _: EmptyTuple => Nil
-      case _: (t *: ts)  => constValue[t].toString :: labelsOf[ts]
+      case _: EmptyTuple => acc
+      case _: (t *: ts)  => labelsOf[ts](constValue[t].toString :: acc)
 
   inline def customNamesOf[T]: List[String] =
-    Macros.nameOf[T].map(_.name)
+    inline Macros.nameOf[T] match {
+      case Nil   => Nil
+      case names => names.map(_.name)
+    }
 
   inline def customFieldNamesOf[T]: Map[String, name] =
-    Macros.fieldNameOf[T].flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
+    inline Macros.fieldNameOf[T] match {
+      case Nil   => Map.empty[String, name]
+      case names => names.flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
+    }
 
   inline given derived[T](using m: Mirror.Of[T]): DeriveConfig[T] =
     inline m match
-      case s: Mirror.SumOf[T] =>
+      case _: Mirror.SumOf[T] =>
         val coproductName: CoproductName =
           CoproductName(
             originalName = constValue[m.MirroredLabel],
@@ -153,11 +158,8 @@ object DeriveConfig {
             typeDiscriminator = Macros.discriminator[T].headOption.map(_.keyName)
           )
 
-        lazy val subClassDescriptions =
-          summonDeriveConfigForCoProduct[m.MirroredElemTypes]
-
-        lazy val desc =
-          mergeAllProducts(subClassDescriptions.map(castTo[DeriveConfig[T]]), coproductName.typeDiscriminator)
+        val subClassDescriptions = summonDeriveConfigForCoProduct[m.MirroredElemTypes]()
+        val desc                 = mergeAllProducts(subClassDescriptions.map(castTo[DeriveConfig[T]]), coproductName.typeDiscriminator)
 
         DeriveConfig.from(tryAllKeys(desc.desc, None, coproductName.alternativeNames))
 
@@ -169,44 +171,39 @@ object DeriveConfig {
             descriptions = Macros.documentationOf[T].map(_.describe)
           )
 
-        lazy val originalFieldNamesList =
-          labelsOf[m.MirroredElemLabels]
+        val originalFieldNamesList = labelsOf[m.MirroredElemLabels]()
+        val customFieldNameMap     = customFieldNamesOf[T]
+        val documentations         = Macros.fieldDocumentationOf[T].toMap
+        val fieldNames             = mapOriginalNames(originalFieldNamesList, documentations, customFieldNameMap)
 
-        lazy val customFieldNameMap =
-          customFieldNamesOf[T]
-
-        lazy val documentations =
-          Macros.fieldDocumentationOf[T].toMap
-
-        lazy val fieldAndDefaultValues: Map[String, Any] =
-          Macros.defaultValuesOf[T].toMap
-
-        lazy val fieldNames =
-          originalFieldNamesList.foldRight(Nil: List[FieldName]) { (str, list) =>
-            val alternativeNames = customFieldNameMap.get(str).map(v => List(v.name)).getOrElse(Nil)
-            val descriptions     = documentations.get(str).map(_.map(_.describe)).getOrElse(Nil)
-            FieldName(str, alternativeNames.toList, descriptions) :: list
-          }
-
-        lazy val fieldConfigs =
-          summonDeriveConfigAll[m.MirroredElemTypes].asInstanceOf[List[DeriveConfig[Any]]]
-
-        lazy val fieldConfigsWithDefaultValues =
+        @threadUnsafe lazy val fieldConfigsWithDefaultValues = {
+          val fieldConfigs          = summonDeriveConfigAll[m.MirroredElemTypes].asInstanceOf[List[DeriveConfig[Any]]]
+          val fieldAndDefaultValues = Macros.defaultValuesOf[T].toMap
           addDefaultValues(fieldAndDefaultValues, originalFieldNamesList, fieldConfigs)
+        }
 
         mergeAllFields(
           fieldConfigsWithDefaultValues,
           productName,
           fieldNames,
-          lst => m.fromProduct(Tuple.fromArray(lst.toArray[Any])),
-          castTo[Product](_).productIterator.toList
+          lst => m.fromProduct(Tuple.fromArray(lst.toArray[Any]))
         )
+
+  private def mapOriginalNames(
+    names: List[String],
+    docs: Map[String, List[describe]],
+    customFieldNames: Map[String, name]
+  ): List[FieldName] =
+    names.foldRight(List.empty[FieldName]) { (str, list) =>
+      val alternativeNames = customFieldNames.get(str).map(v => List(v.name)).getOrElse(Nil)
+      val descriptions     = docs.get(str).map(_.map(_.describe)).getOrElse(Nil)
+      FieldName(str, alternativeNames, descriptions) :: list
+    }
 
   def mergeAllProducts[T](
     allDescs: => List[DeriveConfig[T]],
     typeDiscriminator: Option[String]
-  ): DeriveConfig[T] =
-
+  ): DeriveConfig[T] = {
     val desc =
       typeDiscriminator match {
         case None =>
@@ -235,11 +232,12 @@ object DeriveConfig {
 
                   case None => Nil
                 }
-              }: _*
+              }*
             )
       }
 
     DeriveConfig.from(desc)
+  }
 
   def addDefaultValues(
     defaultValues: Map[String, Any],
@@ -253,12 +251,22 @@ object DeriveConfig {
       }
     }
 
+  @deprecated("use overloaded method without providing `g`")
   def mergeAllFields[T](
     allDescs: => List[DeriveConfig[_]],
     productName: ProductName,
     fieldNames: => List[FieldName],
     f: List[Any] => T,
     g: T => List[Any]
+  ): DeriveConfig[T] =
+    mergeAllFields[T](allDescs, productName, fieldNames, f)
+
+  @targetName("mergeAllFieldsV2")
+  def mergeAllFields[T](
+    allDescs: => List[DeriveConfig[_]],
+    productName: ProductName,
+    fieldNames: List[FieldName],
+    f: List[Any] => T
   ): DeriveConfig[T] =
     if fieldNames.isEmpty then // if there are no fields in the product then the value is the name of the product itself
       val tryAllPaths =
@@ -278,7 +286,7 @@ object DeriveConfig {
         }
 
       val descOfList =
-        Config.collectAll(listOfDesc.head, listOfDesc.tail: _*)
+        Config.collectAll(listOfDesc.head, listOfDesc.tail*)
 
       DeriveConfig(descOfList.map(f), Some(Metadata.Product(productName, fieldNames)))
 


### PR DESCRIPTION
While working on a previous issue, I realised that the derivation of `DeriveConfig` was generating a lot of unnecessary bytecode in Scala 3. This PR reduces it substantially by:
1. Using `val` instead of `lazy val` within inlined methods
2. Putting transformations within non-inlined methods to avoid generating the same `FunctionX` whenever we derive a new `DeriveConfig`
3. Using `@threadUnsafe` whenever we need to use a `lazy val` but don't plan to access it concurrently by multiple threads