### PR TITLE
Table.toGithubFlavouredMarkdown: link to section heading anchors

### DIFF
--- a/core/shared/src/main/scala/zio/config/ConfigDocsModule.scala
+++ b/core/shared/src/main/scala/zio/config/ConfigDocsModule.scala
@@ -432,13 +432,14 @@ trait ConfigDocsModule {
      */
     def githubFlavoured: (Heading, Int, Either[FieldName, Format]) => Link =
       (heading, index, fieldNameOrFormat) => {
-        val headingStr =
-          heading.path
+        val headingStr = {
+          "#" + heading.path
             .map(_.asString(Some("Field Descriptions")))
             .mkString
             .toLowerCase
             .replace(".", "")
-            .replace(" ", "")
+            .replace(" ", "-")
+        }
 
         val name = fieldNameOrFormat.fold(
           _.asString(Some("Field Descriptions")),

--- a/core/shared/src/test/scala/zio/config/GenerateDocsTest.scala
+++ b/core/shared/src/test/scala/zio/config/GenerateDocsTest.scala
@@ -15,17 +15,17 @@ object GenerateDocsTest extends BaseSpec {
           s"""|## Configuration Details
               |
               |
-              ||FieldName|Format                     |Description|Sources|
-              ||---      |---                        |---        |---    |
-              ||         |[all-of](fielddescriptions)|           |       |
+              ||FieldName|Format                       |Description|Sources|
+              ||---      |---                          |---        |---    |
+              ||         |[all-of](#field-descriptions)|           |       |
               |
               |### Field Descriptions
               |
-              ||FieldName                 |Format               |Description                        |Sources|
-              ||---                       |---                  |---                                |---    |
-              ||SECRET                    |primitive            |a text property, Application secret|       |
-              ||[CREDENTIALS](credentials)|[all-of](credentials)|Credentials                        |       |
-              ||[DATABASE](database)      |[all-of](database)   |Database                           |       |
+              ||FieldName                  |Format                |Description                        |Sources|
+              ||---                        |---                   |---                                |---    |
+              ||SECRET                     |primitive             |a text property, Application secret|       |
+              ||[CREDENTIALS](#credentials)|[all-of](#credentials)|Credentials                        |       |
+              ||[DATABASE](#database)      |[all-of](#database)   |Database                           |       |
               |
               |### CREDENTIALS
               |


### PR DESCRIPTION
assume the format of anchor identifiers currently used by both Github and the HTML generator used to build the ZIO website

fix #1542 