### PR TITLE
feat: add kebabCaseLegacy annotation for backward compatibility

### DIFF
--- a/core/shared/src/main/scala/zio/config/KeyConversionFunctions.scala
+++ b/core/shared/src/main/scala/zio/config/KeyConversionFunctions.scala
@@ -36,9 +36,24 @@ private[config] trait KeyConversionFunctions {
 
   /**
    * Convert a camelCase key to kebab-case val s = abcDef toKebabCase(s) === abc-def
+   *
+   * This version handles numeric boundaries properly:
+   * - "myValue123" -> "my-value-123"
+   * - "QAndA" -> "q-and-a"
    */
   val toKebabCase: String => String =
     camelToDelimiter(_, "-")
+
+  /**
+   * Legacy kebab-case conversion that only handles lowercase-uppercase boundaries.
+   * Use this for backward compatibility with configs created before zio-config 4.0.5.
+   *
+   * Example:
+   * - "myValue123" -> "my-value123" (numbers not separated)
+   * - "QAndA" -> "qand-a" (consecutive capitals not separated)
+   */
+  val toKebabCaseLegacy: String => String =
+    input => input.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase
 
   /**
    * Convert a camelCase key to snake_case

--- a/derivation/shared/src/main/scala/zio/config/derivation/annotations.scala
+++ b/derivation/shared/src/main/scala/zio/config/derivation/annotations.scala
@@ -58,6 +58,7 @@ final case class name(name: String)         extends StaticAnnotation
  */
 final case class discriminator(keyName: String = "type") extends StaticAnnotation
 final case class kebabCase()                             extends StaticAnnotation
+final case class kebabCaseLegacy()                       extends StaticAnnotation
 final case class snakeCase()                             extends StaticAnnotation
 final case class prefix(prefix: String)                  extends StaticAnnotation
 final case class postfix(postfix: String)                extends StaticAnnotation

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
@@ -88,6 +88,7 @@ object DeriveConfig {
 
   object KeyModifier {
     case object KebabCase               extends CaseModifier
+    case object KebabCaseLegacy         extends CaseModifier
     case object SnakeCase               extends CaseModifier
     case object NoneModifier            extends CaseModifier
     case class Prefix(prefix: String)   extends KeyModifier
@@ -96,6 +97,7 @@ object DeriveConfig {
     def getModifierFunction(keyModifier: KeyModifier): String => String =
       keyModifier match {
         case KebabCase        => toKebabCase
+        case KebabCaseLegacy  => toKebabCaseLegacy
         case SnakeCase        => toSnakeCase
         case Prefix(prefix)   => addPrefixToKey(prefix)
         case Postfix(postfix) => addPostFixToKey(postfix)
@@ -147,8 +149,9 @@ object DeriveConfig {
     }.toList
 
     val caseModifier = annotations.collectFirst {
-      case _: kebabCase => KeyModifier.KebabCase
-      case _: snakeCase => KeyModifier.SnakeCase
+      case _: kebabCase       => KeyModifier.KebabCase
+      case _: kebabCaseLegacy => KeyModifier.KebabCaseLegacy
+      case _: snakeCase       => KeyModifier.SnakeCase
     }.getOrElse(KeyModifier.NoneModifier)
     modifiers -> caseModifier
   }

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/package.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/package.scala
@@ -18,6 +18,9 @@ package object magnolia {
   type kebabCase = derivation.kebabCase
   val kebabCase: derivation.kebabCase.type = derivation.kebabCase
 
+  type kebabCaseLegacy = derivation.kebabCaseLegacy
+  val kebabCaseLegacy: derivation.kebabCaseLegacy.type = derivation.kebabCaseLegacy
+
   type snakeCase = derivation.snakeCase
   val snakeCase: derivation.snakeCase.type = derivation.snakeCase
 

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -170,22 +170,25 @@ import scala.deriving.*
       case names => names.flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
     }
 
-  inline def keyModifiersOf[T]: (List[KeyModifier], KeyModifier.CaseModifier) =
+  inline def keyModifiersOf[T]: (List[KeyModifier], CaseModifier) =
     val modifiers =
-      Macros.anns[T, prefix]("zio.config.derivation.prefix").map(p => KeyModifier.Prefix(p.prefix)) :::
-        Macros.anns[T, postfix]("zio.config.derivation.postfix").map(p => KeyModifier.Postfix(p.postfix))
+      ${ Macros.anns[T, prefix]("zio.config.derivation.prefix") }.map(p => KeyModifier.Prefix(p.prefix)) :::
+        ${ Macros.anns[T, postfix]("zio.config.derivation.postfix") }.map(p => KeyModifier.Postfix(p.postfix))
 
     val caseModifier =
-      Macros
-        .anns[T, kebabCase]("zio.config.derivation.kebabCase")
+      ${ Macros.anns[T, kebabCase]("zio.config.derivation.kebabCase") }
         .headOption
         .map(_ => KeyModifier.KebabCase)
         .orElse(
-          Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy").headOption.map(_ =>
-            KeyModifier.KebabCaseLegacy
-          )
+          ${ Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy") }
+            .headOption
+            .map(_ => KeyModifier.KebabCaseLegacy)
         )
-        .orElse(Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase").headOption.map(_ => KeyModifier.SnakeCase))
+        .orElse(
+          ${ Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase") }
+            .headOption
+            .map(_ => KeyModifier.SnakeCase)
+        )
         .getOrElse(KeyModifier.NoneModifier)
 
     (modifiers, caseModifier)
@@ -239,7 +242,7 @@ import scala.deriving.*
     docs: Map[String, List[describe]],
     customFieldNames: Map[String, name],
     keyModifiers: List[KeyModifier],
-    caseModifier: KeyModifier.CaseModifier
+    caseModifier: CaseModifier
   ): List[FieldName] =
     names.foldRight(List.empty[FieldName]) { (str, list) =>
       val alternativeNames = customFieldNames.get(str).map(v => List(v.name)).getOrElse(Nil)

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -13,7 +13,7 @@ import scala.annotation.{targetName, threadUnsafe}
 import scala.compiletime.*
 import scala.deriving.*
 
-final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
+  final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
   def ??(description: String): DeriveConfig[A] =
     describe(description)
 
@@ -30,7 +30,7 @@ final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.
     DeriveConfig(desc.mapOrFail(f))
 }
 
-object DeriveConfig {
+  object DeriveConfig {
 
   def apply[A](implicit ev: DeriveConfig[A]): DeriveConfig[A] =
     ev
@@ -114,6 +114,27 @@ object DeriveConfig {
   given mapDesc[A](using ev: DeriveConfig[A]): DeriveConfig[Map[String, A]] =
     DeriveConfig.from(table(ev.desc))
 
+  sealed trait KeyModifier
+  sealed trait CaseModifier extends KeyModifier
+
+  object KeyModifier {
+    case object KebabCase       extends CaseModifier
+    case object KebabCaseLegacy extends CaseModifier
+    case object SnakeCase       extends CaseModifier
+    case object NoneModifier    extends CaseModifier
+    final case class Prefix(prefix: String)   extends KeyModifier
+    final case class Postfix(postfix: String) extends KeyModifier
+
+    def modifierFunction(keyModifier: KeyModifier): String => String =
+      keyModifier match
+        case KebabCase       => toKebabCase
+        case KebabCaseLegacy => toKebabCaseLegacy
+        case SnakeCase       => toSnakeCase
+        case Prefix(prefix)  => addPrefixToKey(prefix)
+        case Postfix(postfix) => addPostFixToKey(postfix)
+        case NoneModifier    => identity
+  }
+
   inline def summonDeriveConfigForCoProduct[T <: Tuple]: List[DeriveConfig[Any]] =
     inline erasedValue[T] match {
       case _: EmptyTuple => Nil
@@ -149,6 +170,26 @@ object DeriveConfig {
       case names => names.flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
     }
 
+  inline def keyModifiersOf[T]: (List[KeyModifier], KeyModifier.CaseModifier) =
+    val modifiers =
+      Macros.anns[T, prefix]("zio.config.derivation.prefix").map(p => KeyModifier.Prefix(p.prefix)) :::
+        Macros.anns[T, postfix]("zio.config.derivation.postfix").map(p => KeyModifier.Postfix(p.postfix))
+
+    val caseModifier =
+      Macros
+        .anns[T, kebabCase]("zio.config.derivation.kebabCase")
+        .headOption
+        .map(_ => KeyModifier.KebabCase)
+        .orElse(
+          Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy").headOption.map(_ =>
+            KeyModifier.KebabCaseLegacy
+          )
+        )
+        .orElse(Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase").headOption.map(_ => KeyModifier.SnakeCase))
+        .getOrElse(KeyModifier.NoneModifier)
+
+    (modifiers, caseModifier)
+
   inline given derived[T](using m: Mirror.Of[T]): DeriveConfig[T] =
     inline m match
       case _: Mirror.SumOf[T] =>
@@ -173,10 +214,12 @@ object DeriveConfig {
             descriptions = Macros.documentationOf[T].map(_.describe)
           )
 
-        val originalFieldNamesList = labelsOf[m.MirroredElemLabels]
-        val customFieldNameMap     = customFieldNamesOf[T]
-        val documentations         = Macros.fieldDocumentationOf[T].toMap
-        val fieldNames             = mapOriginalNames(originalFieldNamesList, documentations, customFieldNameMap)
+        val originalFieldNamesList      = labelsOf[m.MirroredElemLabels]
+        val customFieldNameMap          = customFieldNamesOf[T]
+        val documentations              = Macros.fieldDocumentationOf[T].toMap
+        val (keyModifiers, caseModifier) = keyModifiersOf[T]
+        val fieldNames                  =
+          mapOriginalNames(originalFieldNamesList, documentations, customFieldNameMap, keyModifiers, caseModifier)
 
         @threadUnsafe lazy val fieldConfigsWithDefaultValues = {
           val fieldConfigs          = summonDeriveConfigAll[m.MirroredElemTypes].asInstanceOf[List[DeriveConfig[Any]]]
@@ -194,12 +237,21 @@ object DeriveConfig {
   private def mapOriginalNames(
     names: List[String],
     docs: Map[String, List[describe]],
-    customFieldNames: Map[String, name]
+    customFieldNames: Map[String, name],
+    keyModifiers: List[KeyModifier],
+    caseModifier: KeyModifier.CaseModifier
   ): List[FieldName] =
     names.foldRight(List.empty[FieldName]) { (str, list) =>
       val alternativeNames = customFieldNames.get(str).map(v => List(v.name)).getOrElse(Nil)
       val descriptions     = docs.get(str).map(_.map(_.describe)).getOrElse(Nil)
-      FieldName(str, alternativeNames, descriptions) :: list
+      val modifyKey        = keyModifiers
+        .foldLeft(identity[String] _) { case (all, modifier) =>
+          all.andThen(KeyModifier.modifierFunction(modifier))
+        }
+        .andThen(KeyModifier.modifierFunction(caseModifier))
+      val targetName       = customFieldNames.get(str).map(_.name).getOrElse(modifyKey(str))
+
+      FieldName(targetName, alternativeNames, descriptions) :: list
     }
 
   def mergeAllProducts[T](

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -341,25 +341,27 @@ import scala.quoted.*
   def castTo[T](a: Any): T =
     a.asInstanceOf[T]
 
-  private def keyModifiersOfImpl[T: Type](using Quotes): Expr[(List[KeyModifier], CaseModifier)] = {
-    val prefixes = Macros.anns[T, prefix]("zio.config.derivation.prefix").valueOrAbort
-    val postfixes = Macros.anns[T, postfix]("zio.config.derivation.postfix").valueOrAbort
-    val kebabs = Macros.anns[T, kebabCase]("zio.config.derivation.kebabCase").valueOrAbort
-    val kebabsLegacy = Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy").valueOrAbort
-    val snakes = Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase").valueOrAbort
+  private def keyModifiersOfImpl[T: Type](using Quotes): Expr[(List[KeyModifier], CaseModifier)] =
+    val prefixesExpr     = Macros.anns[T, prefix]("zio.config.derivation.prefix")
+    val postfixesExpr    = Macros.anns[T, postfix]("zio.config.derivation.postfix")
+    val kebabsExpr       = Macros.anns[T, kebabCase]("zio.config.derivation.kebabCase")
+    val kebabsLegacyExpr = Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy")
+    val snakesExpr       = Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase")
 
-    val modifierExprs: List[Expr[KeyModifier]] =
-      prefixes.map(p => Expr(KeyModifier.Prefix(p.prefix))) :::
-        postfixes.map(p => Expr(KeyModifier.Postfix(p.postfix)))
+    val modifiersExpr: Expr[List[KeyModifier]] = '{
+      $prefixesExpr.map(p => KeyModifier.Prefix(p.prefix)) :::
+        $postfixesExpr.map(p => KeyModifier.Postfix(p.postfix))
+    }
 
-    val caseModifier: CaseModifier =
+    val caseModifierExpr: Expr[CaseModifier] = '{
+      val kebabs       = $kebabsExpr
+      val kebabsLegacy = $kebabsLegacyExpr
+      val snakes       = $snakesExpr
       if (kebabs.nonEmpty) KeyModifier.KebabCase
       else if (kebabsLegacy.nonEmpty) KeyModifier.KebabCaseLegacy
       else if (snakes.nonEmpty) KeyModifier.SnakeCase
       else KeyModifier.NoneModifier
+    }
 
-    val listExpr = Expr.ofList(modifierExprs)
-    val caseExpr = Expr(caseModifier)
-    '{ ($listExpr, $caseExpr) }
-  }
+    '{ ($modifiersExpr, $caseModifierExpr) }
 }

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -12,6 +12,7 @@ import java.util.UUID
 import scala.annotation.{targetName, threadUnsafe}
 import scala.compiletime.*
 import scala.deriving.*
+import scala.quoted.*
 
   final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
   def ??(description: String): DeriveConfig[A] =
@@ -170,32 +171,8 @@ import scala.deriving.*
       case names => names.flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
     }
 
-  inline def keyModifiersOf[T]: (List[KeyModifier], CaseModifier) = {
-    val modifiers =
-      Macros.anns[T, prefix]("zio.config.derivation.prefix").map(p => KeyModifier.Prefix(p.prefix)) :::
-        Macros.anns[T, postfix]("zio.config.derivation.postfix").map(p => KeyModifier.Postfix(p.postfix))
-
-    val caseModifier =
-      Macros
-        .anns[T, kebabCase]("zio.config.derivation.kebabCase")
-        .headOption
-        .map(_ => KeyModifier.KebabCase)
-        .orElse(
-          Macros
-            .anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy")
-            .headOption
-            .map(_ => KeyModifier.KebabCaseLegacy)
-        )
-        .orElse(
-          Macros
-            .anns[T, snakeCase]("zio.config.derivation.snakeCase")
-            .headOption
-            .map(_ => KeyModifier.SnakeCase)
-        )
-        .getOrElse(KeyModifier.NoneModifier)
-
-    (modifiers, caseModifier)
-  }
+  inline def keyModifiersOf[T]: (List[KeyModifier], CaseModifier) =
+    ${ keyModifiersOfImpl[T] }
 
   inline given derived[T](using m: Mirror.Of[T]): DeriveConfig[T] =
     inline m match
@@ -363,4 +340,26 @@ import scala.deriving.*
 
   def castTo[T](a: Any): T =
     a.asInstanceOf[T]
+
+  private def keyModifiersOfImpl[T: Type](using Quotes): Expr[(List[KeyModifier], CaseModifier)] = {
+    val prefixes = Macros.anns[T, prefix]("zio.config.derivation.prefix").valueOrAbort
+    val postfixes = Macros.anns[T, postfix]("zio.config.derivation.postfix").valueOrAbort
+    val kebabs = Macros.anns[T, kebabCase]("zio.config.derivation.kebabCase").valueOrAbort
+    val kebabsLegacy = Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy").valueOrAbort
+    val snakes = Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase").valueOrAbort
+
+    val modifierExprs: List[Expr[KeyModifier]] =
+      prefixes.map(p => Expr(KeyModifier.Prefix(p.prefix))) :::
+        postfixes.map(p => Expr(KeyModifier.Postfix(p.postfix)))
+
+    val caseModifier: CaseModifier =
+      if (kebabs.nonEmpty) KeyModifier.KebabCase
+      else if (kebabsLegacy.nonEmpty) KeyModifier.KebabCaseLegacy
+      else if (snakes.nonEmpty) KeyModifier.SnakeCase
+      else KeyModifier.NoneModifier
+
+    val listExpr = Expr.ofList(modifierExprs)
+    val caseExpr = Expr(caseModifier)
+    '{ ($listExpr, $caseExpr) }
+  }
 }

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -170,28 +170,32 @@ import scala.deriving.*
       case names => names.flatMap { case (str, nmes) => nmes.map(name => (str, name)) }.toMap
     }
 
-  inline def keyModifiersOf[T]: (List[KeyModifier], CaseModifier) =
+  inline def keyModifiersOf[T]: (List[KeyModifier], CaseModifier) = {
     val modifiers =
-      ${ Macros.anns[T, prefix]("zio.config.derivation.prefix") }.map(p => KeyModifier.Prefix(p.prefix)) :::
-        ${ Macros.anns[T, postfix]("zio.config.derivation.postfix") }.map(p => KeyModifier.Postfix(p.postfix))
+      Macros.anns[T, prefix]("zio.config.derivation.prefix").map(p => KeyModifier.Prefix(p.prefix)) :::
+        Macros.anns[T, postfix]("zio.config.derivation.postfix").map(p => KeyModifier.Postfix(p.postfix))
 
     val caseModifier =
-      ${ Macros.anns[T, kebabCase]("zio.config.derivation.kebabCase") }
+      Macros
+        .anns[T, kebabCase]("zio.config.derivation.kebabCase")
         .headOption
         .map(_ => KeyModifier.KebabCase)
         .orElse(
-          ${ Macros.anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy") }
+          Macros
+            .anns[T, kebabCaseLegacy]("zio.config.derivation.kebabCaseLegacy")
             .headOption
             .map(_ => KeyModifier.KebabCaseLegacy)
         )
         .orElse(
-          ${ Macros.anns[T, snakeCase]("zio.config.derivation.snakeCase") }
+          Macros
+            .anns[T, snakeCase]("zio.config.derivation.snakeCase")
             .headOption
             .map(_ => KeyModifier.SnakeCase)
         )
         .getOrElse(KeyModifier.NoneModifier)
 
     (modifiers, caseModifier)
+  }
 
   inline given derived[T](using m: Mirror.Of[T]): DeriveConfig[T] =
     inline m match

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/package.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/package.scala
@@ -15,6 +15,9 @@ package object magnolia {
   type name = derivation.name
   val name: derivation.name.type = derivation.name
 
+  type kebabCaseLegacy = derivation.kebabCaseLegacy
+  val kebabCaseLegacy: derivation.kebabCaseLegacy.type = derivation.kebabCaseLegacy
+
   type discriminator = derivation.discriminator
   val discriminator: derivation.discriminator.type = derivation.discriminator
 

--- a/typesafe-magnolia-tests/shared/src/test/scala/zio/config/magnolia/AnnotationsTest.scala
+++ b/typesafe-magnolia-tests/shared/src/test/scala/zio/config/magnolia/AnnotationsTest.scala
@@ -21,6 +21,15 @@ object AnnotationsTest extends ZIOSpecDefault {
     val myConfigAutomatic: Config[MyConfig] = deriveConfig[MyConfig]
   }
 
+  object KebabCaseLegacyTest {
+    @kebabCaseLegacy
+    case class InstantId(instantIdQAndA: String)
+    @kebabCaseLegacy
+    case class MyConfig(instantId: InstantId)
+
+    val myConfigAutomatic: Config[MyConfig] = deriveConfig[MyConfig]
+  }
+
   object SnakeTest {
     @snakeCase
     case class Foo(fooFoo: String)
@@ -73,6 +82,21 @@ object AnnotationsTest extends ZIOSpecDefault {
         val result: IO[Config.Error, MyConfig] =
           read(myConfigAutomatic from TypesafeConfigProvider.fromHoconString(hocconConfig))
         val expected                           = MyConfig(Foo("value1"), AnotherFoo("value2"), Bar("value3"))
+        assertZIO(result)(equalTo(expected))
+      },
+      test("kebab case legacy - backward compatible with pre-4.0.5 configs") {
+        import KebabCaseLegacyTest._
+        // Legacy behavior: consecutive capitals are not separated
+        // instantIdQAndA -> instant-id-qand-a (NOT instant-id-q-and-a)
+        val hocconConfig                       =
+          s"""
+             |instant-id {
+             |  instant-id-qand-a = "value1"
+             |}
+             |""".stripMargin
+        val result: IO[Config.Error, MyConfig] =
+          read(myConfigAutomatic from TypesafeConfigProvider.fromHoconString(hocconConfig))
+        val expected                           = MyConfig(InstantId("value1"))
         assertZIO(result)(equalTo(expected))
       },
       test("snake case") {


### PR DESCRIPTION
## Summary                               
                                           
Fixes #1612                              
                                           
Add `@kebabCaseLegacy` annotation for backward compatibility with pre-4.0.5 configs.

### Problem             
After upgrading to zio-config 4.0.5 (ZIO 2.1.20), `@kebabCase` behavior changed:  
- Before: `instantIdQAndA` → `instant-id-qand-a`      
- After: `instantIdQAndA` → `instant-id-q-and-a`

This breaks existing HOCON config files. 
                                           
### Solution                                           
```scala             
@kebabCaseLegacy
case class InstantId(instantIdQAndA: String)                                  
// Uses: instant-id-qand-a (legacy behavior)
```