### PR TITLE
Add DeriveConfig support for Map with non-String keys via ConfigKeyDecoder

### DIFF
--- a/core/shared/src/main/scala/zio/config/KeyConversionFunctions.scala
+++ b/core/shared/src/main/scala/zio/config/KeyConversionFunctions.scala
@@ -38,19 +38,19 @@ private[config] trait KeyConversionFunctions {
    * Convert a camelCase key to kebab-case val s = abcDef toKebabCase(s) === abc-def
    *
    * This version handles numeric boundaries properly:
-   * - "myValue123" -> "my-value-123"
-   * - "QAndA" -> "q-and-a"
+   *   - "myValue123" -> "my-value-123"
+   *   - "QAndA" -> "q-and-a"
    */
   val toKebabCase: String => String =
     camelToDelimiter(_, "-")
 
   /**
-   * Legacy kebab-case conversion that only handles lowercase-uppercase boundaries.
-   * Use this for backward compatibility with configs created before zio-config 4.0.5.
+   * Legacy kebab-case conversion that only handles lowercase-uppercase boundaries. Use this for backward compatibility
+   * with configs created before zio-config 4.0.5.
    *
    * Example:
-   * - "myValue123" -> "my-value123" (numbers not separated)
-   * - "QAndA" -> "qand-a" (consecutive capitals not separated)
+   *   - "myValue123" -> "my-value123" (numbers not separated)
+   *   - "QAndA" -> "qand-a" (consecutive capitals not separated)
    */
   val toKebabCaseLegacy: String => String =
     input => input.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase

--- a/docs/automatic-derivation-of-config.md
+++ b/docs/automatic-derivation-of-config.md
@@ -209,6 +209,41 @@ object AwsRegion {
 
 
 
+### Maps with non-String keys
+
+By default, `Map[String, V]` is supported out of the box. For maps with non-String key types like `UUID`, `Int`, or custom wrapper types, you need a `ConfigKeyDecoder` instance for the key type.
+
+Built-in `ConfigKeyDecoder` instances are provided for `String`, `UUID`, `Int`, and `Long`:
+
+```scala
+import zio.config.magnolia._
+
+case class MyConfig(entries: Map[UUID, String])
+
+// Works out of the box — UUID has a built-in ConfigKeyDecoder
+deriveConfig[MyConfig]
+```
+
+For custom key types, provide a `ConfigKeyDecoder` instance:
+
+```scala
+import zio.config.magnolia._
+
+case class EntryId(value: String)
+
+object EntryId {
+  implicit val keyDecoder: ConfigKeyDecoder[EntryId] =
+    (key: String) => Right(EntryId(key))
+
+  implicit val deriveConfig: DeriveConfig[EntryId] =
+    DeriveConfig[String].map(EntryId(_))
+}
+
+case class MyConfig(entries: Map[EntryId, String])
+
+deriveConfig[MyConfig]
+```
+
 ### Where to place these implicits ?
 
 If the types are owned by us, then the best place to keep implicit instance is the companion object of that type.

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/ConfigKeyDecoder.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/ConfigKeyDecoder.scala
@@ -1,0 +1,28 @@
+package zio.config.magnolia
+
+import zio.Config
+
+import java.util.UUID
+import scala.util.Try
+
+trait ConfigKeyDecoder[A] {
+  def decode(key: String): Either[Config.Error, A]
+}
+
+object ConfigKeyDecoder {
+  def apply[A](implicit ev: ConfigKeyDecoder[A]): ConfigKeyDecoder[A] = ev
+
+  implicit val string: ConfigKeyDecoder[String] = (key: String) => Right(key)
+
+  implicit val uuid: ConfigKeyDecoder[UUID] = (key: String) =>
+    Try(UUID.fromString(key)).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected a UUID but found: $key"))
+
+  implicit val int: ConfigKeyDecoder[Int] = (key: String) =>
+    Try(key.toInt).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected an Int but found: $key"))
+
+  implicit val long: ConfigKeyDecoder[Long] = (key: String) =>
+    Try(key.toLong).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected a Long but found: $key"))
+}

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
@@ -78,14 +78,16 @@ object DeriveConfig {
   implicit def implicitNonEmptyChunkDesc[A: DeriveConfig]: DeriveConfig[NonEmptyChunk[A]] =
     DeriveConfig(Config.nonEmptyChunkOf(DeriveConfig[A].desc))
 
-  implicit def implicitMapDesc[K, V](implicit evKey: ConfigKeyDecoder[K], evValue: DeriveConfig[V]): DeriveConfig[Map[K, V]] =
+  implicit def implicitMapDesc[K, V](implicit
+    evKey: ConfigKeyDecoder[K],
+    evValue: DeriveConfig[V]
+  ): DeriveConfig[Map[K, V]] =
     DeriveConfig(Config.table(evValue.desc)).mapOrFail { stringMap =>
-      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) {
-        case (acc, (keyStr, value)) =>
-          for {
-            map <- acc
-            key <- evKey.decode(keyStr)
-          } yield map + (key -> value)
+      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) { case (acc, (keyStr, value)) =>
+        for {
+          map <- acc
+          key <- evKey.decode(keyStr)
+        } yield map + (key -> value)
       }
     }
 

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
@@ -78,7 +78,10 @@ object DeriveConfig {
   implicit def implicitNonEmptyChunkDesc[A: DeriveConfig]: DeriveConfig[NonEmptyChunk[A]] =
     DeriveConfig(Config.nonEmptyChunkOf(DeriveConfig[A].desc))
 
-  implicit def implicitMapDesc[K, V](implicit
+  implicit def implicitMapDesc[A: DeriveConfig]: DeriveConfig[Map[String, A]] =
+    DeriveConfig(Config.table(implicitly[DeriveConfig[A]].desc))
+
+  implicit def implicitMapDescWithKeyDecoder[K, V](implicit
     evKey: ConfigKeyDecoder[K],
     evValue: DeriveConfig[V]
   ): DeriveConfig[Map[K, V]] =

--- a/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-2.12-2.13/zio/config/magnolia/DeriveConfig.scala
@@ -78,8 +78,16 @@ object DeriveConfig {
   implicit def implicitNonEmptyChunkDesc[A: DeriveConfig]: DeriveConfig[NonEmptyChunk[A]] =
     DeriveConfig(Config.nonEmptyChunkOf(DeriveConfig[A].desc))
 
-  implicit def implicitMapDesc[A: DeriveConfig]: DeriveConfig[Map[String, A]] =
-    DeriveConfig(Config.table(implicitly[DeriveConfig[A]].desc))
+  implicit def implicitMapDesc[K, V](implicit evKey: ConfigKeyDecoder[K], evValue: DeriveConfig[V]): DeriveConfig[Map[K, V]] =
+    DeriveConfig(Config.table(evValue.desc)).mapOrFail { stringMap =>
+      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) {
+        case (acc, (keyStr, value)) =>
+          for {
+            map <- acc
+            key <- evKey.decode(keyStr)
+          } yield map + (key -> value)
+      }
+    }
 
   type Typeclass[T] = DeriveConfig[T]
 

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/ConfigKeyDecoder.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/ConfigKeyDecoder.scala
@@ -1,0 +1,28 @@
+package zio.config.magnolia
+
+import zio.Config
+
+import java.util.UUID
+import scala.util.Try
+
+trait ConfigKeyDecoder[A] {
+  def decode(key: String): Either[Config.Error, A]
+}
+
+object ConfigKeyDecoder {
+  def apply[A](using ev: ConfigKeyDecoder[A]): ConfigKeyDecoder[A] = ev
+
+  given ConfigKeyDecoder[String] = (key: String) => Right(key)
+
+  given ConfigKeyDecoder[UUID] = (key: String) =>
+    Try(UUID.fromString(key)).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected a UUID but found: $key"))
+
+  given ConfigKeyDecoder[Int] = (key: String) =>
+    Try(key.toInt).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected an Int but found: $key"))
+
+  given ConfigKeyDecoder[Long] = (key: String) =>
+    Try(key.toLong).toEither.left
+      .map(_ => Config.Error.InvalidData(message = s"Expected a Long but found: $key"))
+}

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -112,7 +112,13 @@ object DeriveConfig {
   given nonEmptyChunkDesc[A](using ev: DeriveConfig[A]): DeriveConfig[NonEmptyChunk[A]] =
     DeriveConfig.from(nonEmptyChunkOf(ev.desc))
 
-  given mapDesc[K, V](using evKey: ConfigKeyDecoder[K], evValue: DeriveConfig[V]): DeriveConfig[Map[K, V]] =
+  given mapDesc[A](using ev: DeriveConfig[A]): DeriveConfig[Map[String, A]] =
+    DeriveConfig.from(table(ev.desc))
+
+  given mapDescWithKeyDecoder[K, V](using
+    evKey: ConfigKeyDecoder[K],
+    evValue: DeriveConfig[V]
+  ): DeriveConfig[Map[K, V]] =
     DeriveConfig.from(table(evValue.desc)).mapOrFail { stringMap =>
       stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) { case (acc, (keyStr, value)) =>
         for {

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -14,7 +14,7 @@ import scala.compiletime.*
 import scala.deriving.*
 import scala.quoted.*
 
-  final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
+final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.Metadata] = None) {
   def ??(description: String): DeriveConfig[A] =
     describe(description)
 
@@ -112,8 +112,16 @@ import scala.quoted.*
   given nonEmptyChunkDesc[A](using ev: DeriveConfig[A]): DeriveConfig[NonEmptyChunk[A]] =
     DeriveConfig.from(nonEmptyChunkOf(ev.desc))
 
-  given mapDesc[A](using ev: DeriveConfig[A]): DeriveConfig[Map[String, A]] =
-    DeriveConfig.from(table(ev.desc))
+  given mapDesc[K, V](using evKey: ConfigKeyDecoder[K], evValue: DeriveConfig[V]): DeriveConfig[Map[K, V]] =
+    DeriveConfig.from(table(evValue.desc)).mapOrFail { stringMap =>
+      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) {
+        case (acc, (keyStr, value)) =>
+          for {
+            map <- acc
+            key <- evKey.decode(keyStr)
+          } yield map + (key -> value)
+      }
+    }
 
   sealed trait KeyModifier
   sealed trait CaseModifier extends KeyModifier

--- a/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
+++ b/magnolia/shared/src/main/scala-dotty/zio/config/magnolia/DeriveConfig.scala
@@ -31,7 +31,7 @@ final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.
     DeriveConfig(desc.mapOrFail(f))
 }
 
-  object DeriveConfig {
+object DeriveConfig {
 
   def apply[A](implicit ev: DeriveConfig[A]): DeriveConfig[A] =
     ev
@@ -114,12 +114,11 @@ final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.
 
   given mapDesc[K, V](using evKey: ConfigKeyDecoder[K], evValue: DeriveConfig[V]): DeriveConfig[Map[K, V]] =
     DeriveConfig.from(table(evValue.desc)).mapOrFail { stringMap =>
-      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) {
-        case (acc, (keyStr, value)) =>
-          for {
-            map <- acc
-            key <- evKey.decode(keyStr)
-          } yield map + (key -> value)
+      stringMap.foldLeft[Either[Config.Error, Map[K, V]]](Right(Map.empty)) { case (acc, (keyStr, value)) =>
+        for {
+          map <- acc
+          key <- evKey.decode(keyStr)
+        } yield map + (key -> value)
       }
     }
 
@@ -127,21 +126,21 @@ final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.
   sealed trait CaseModifier extends KeyModifier
 
   object KeyModifier {
-    case object KebabCase       extends CaseModifier
-    case object KebabCaseLegacy extends CaseModifier
-    case object SnakeCase       extends CaseModifier
-    case object NoneModifier    extends CaseModifier
+    case object KebabCase                     extends CaseModifier
+    case object KebabCaseLegacy               extends CaseModifier
+    case object SnakeCase                     extends CaseModifier
+    case object NoneModifier                  extends CaseModifier
     final case class Prefix(prefix: String)   extends KeyModifier
     final case class Postfix(postfix: String) extends KeyModifier
 
     def modifierFunction(keyModifier: KeyModifier): String => String =
       keyModifier match
-        case KebabCase       => toKebabCase
-        case KebabCaseLegacy => toKebabCaseLegacy
-        case SnakeCase       => toSnakeCase
-        case Prefix(prefix)  => addPrefixToKey(prefix)
+        case KebabCase        => toKebabCase
+        case KebabCaseLegacy  => toKebabCaseLegacy
+        case SnakeCase        => toSnakeCase
+        case Prefix(prefix)   => addPrefixToKey(prefix)
         case Postfix(postfix) => addPostFixToKey(postfix)
-        case NoneModifier    => identity
+        case NoneModifier     => identity
   }
 
   inline def summonDeriveConfigForCoProduct[T <: Tuple]: List[DeriveConfig[Any]] =
@@ -206,11 +205,11 @@ final case class DeriveConfig[A](desc: Config[A], metadata: Option[DeriveConfig.
             descriptions = Macros.documentationOf[T].map(_.describe)
           )
 
-        val originalFieldNamesList      = labelsOf[m.MirroredElemLabels]
-        val customFieldNameMap          = customFieldNamesOf[T]
-        val documentations              = Macros.fieldDocumentationOf[T].toMap
+        val originalFieldNamesList       = labelsOf[m.MirroredElemLabels]
+        val customFieldNameMap           = customFieldNamesOf[T]
+        val documentations               = Macros.fieldDocumentationOf[T].toMap
         val (keyModifiers, caseModifier) = keyModifiersOf[T]
-        val fieldNames                  =
+        val fieldNames                   =
           mapOriginalNames(originalFieldNamesList, documentations, customFieldNameMap, keyModifiers, caseModifier)
 
         @threadUnsafe lazy val fieldConfigsWithDefaultValues = {

--- a/magnolia/shared/src/test/scala-2.12-2.13/zio/config/magnolia/MapKeySpec.scala
+++ b/magnolia/shared/src/test/scala-2.12-2.13/zio/config/magnolia/MapKeySpec.scala
@@ -1,0 +1,80 @@
+package zio.config.magnolia
+
+import zio.ConfigProvider
+import zio.test.Assertion._
+import zio.test._
+
+import java.util.UUID
+
+object MapKeySpec extends ZIOSpecDefault {
+
+  final case class Inner(x: Int, y: String)
+
+  final case class WithUuidMap(entries: Map[UUID, Inner])
+
+  def spec =
+    suite("Map key decoding")(
+      test("Map[String, Int] — backwards compatible") {
+        val map    = Map(
+          "entries.a" -> "1",
+          "entries.b" -> "2"
+        )
+        val config = deriveConfig[Map[String, Int]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+          equalTo(Map("a" -> 1, "b" -> 2))
+        )
+      },
+      test("Map[UUID, String] — UUID keys parsed from config") {
+        check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
+          val map    = Map(
+            s"entries.$uuid1" -> "alpha",
+            s"entries.$uuid2" -> "beta"
+          )
+          val config = deriveConfig[Map[UUID, String]]
+          assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+            equalTo(Map(uuid1 -> "alpha", uuid2 -> "beta"))
+          )
+        }
+      },
+      test("Map[Int, String] — Int keys parsed from config") {
+        val map    = Map(
+          "entries.1" -> "one",
+          "entries.2" -> "two"
+        )
+        val config = deriveConfig[Map[Int, String]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+          equalTo(Map(1 -> "one", 2 -> "two"))
+        )
+      },
+      test("Case class containing Map[UUID, CaseClass] — automatic derivation") {
+        check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
+          val map    = Map(
+            s"entries.$uuid1.x" -> "10",
+            s"entries.$uuid1.y" -> "hello",
+            s"entries.$uuid2.x" -> "20",
+            s"entries.$uuid2.y" -> "world"
+          )
+          val config = deriveConfig[WithUuidMap]
+          assertZIO(ConfigProvider.fromMap(map).load(config))(
+            equalTo(
+              WithUuidMap(
+                Map(
+                  uuid1 -> Inner(10, "hello"),
+                  uuid2 -> Inner(20, "world")
+                )
+              )
+            )
+          )
+        }
+      },
+      test("Invalid UUID key — error message propagation") {
+        val map    = Map(
+          "entries.not-a-uuid" -> "value"
+        )
+        val config = deriveConfig[Map[UUID, String]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")).either)(
+          isLeft
+        )
+      }
+    )
+}

--- a/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/MapKeySpec.scala
+++ b/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/MapKeySpec.scala
@@ -12,11 +12,10 @@ object MapKeySpec extends ZIOSpecDefault {
 
   final case class WithUuidMap(entries: Map[UUID, Inner])
 
-
   def spec =
     suite("Map key decoding")(
       test("Map[String, Int] — backwards compatible") {
-        val map = Map(
+        val map    = Map(
           "entries.a" -> "1",
           "entries.b" -> "2"
         )
@@ -27,7 +26,7 @@ object MapKeySpec extends ZIOSpecDefault {
       },
       test("Map[UUID, String] — UUID keys parsed from config") {
         check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
-          val map = Map(
+          val map    = Map(
             s"entries.${uuid1}" -> "alpha",
             s"entries.${uuid2}" -> "beta"
           )
@@ -38,7 +37,7 @@ object MapKeySpec extends ZIOSpecDefault {
         }
       },
       test("Map[Int, String] — Int keys parsed from config") {
-        val map = Map(
+        val map    = Map(
           "entries.1" -> "one",
           "entries.2" -> "two"
         )
@@ -48,7 +47,7 @@ object MapKeySpec extends ZIOSpecDefault {
         )
       },
       test("Invalid UUID key — error message propagation") {
-        val map = Map(
+        val map    = Map(
           "entries.not-a-uuid" -> "value"
         )
         val config = deriveConfig[Map[UUID, String]]
@@ -58,7 +57,7 @@ object MapKeySpec extends ZIOSpecDefault {
       },
       test("Case class containing Map[UUID, CaseClass] — automatic derivation") {
         check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
-          val map = Map(
+          val map    = Map(
             s"entries.${uuid1}.x" -> "10",
             s"entries.${uuid1}.y" -> "hello",
             s"entries.${uuid2}.x" -> "20",
@@ -66,10 +65,14 @@ object MapKeySpec extends ZIOSpecDefault {
           )
           val config = deriveConfig[WithUuidMap]
           assertZIO(ConfigProvider.fromMap(map).load(config))(
-            equalTo(WithUuidMap(Map(
-              uuid1 -> Inner(10, "hello"),
-              uuid2 -> Inner(20, "world")
-            )))
+            equalTo(
+              WithUuidMap(
+                Map(
+                  uuid1 -> Inner(10, "hello"),
+                  uuid2 -> Inner(20, "world")
+                )
+              )
+            )
           )
         }
       }

--- a/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/MapKeySpec.scala
+++ b/magnolia/shared/src/test/scala-dotty/zio/config/magnolia/MapKeySpec.scala
@@ -1,0 +1,77 @@
+package zio.config.magnolia
+
+import zio.ConfigProvider
+import zio.test.Assertion._
+import zio.test._
+
+import java.util.UUID
+
+object MapKeySpec extends ZIOSpecDefault {
+
+  final case class Inner(x: Int, y: String)
+
+  final case class WithUuidMap(entries: Map[UUID, Inner])
+
+
+  def spec =
+    suite("Map key decoding")(
+      test("Map[String, Int] — backwards compatible") {
+        val map = Map(
+          "entries.a" -> "1",
+          "entries.b" -> "2"
+        )
+        val config = deriveConfig[Map[String, Int]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+          equalTo(Map("a" -> 1, "b" -> 2))
+        )
+      },
+      test("Map[UUID, String] — UUID keys parsed from config") {
+        check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
+          val map = Map(
+            s"entries.${uuid1}" -> "alpha",
+            s"entries.${uuid2}" -> "beta"
+          )
+          val config = deriveConfig[Map[UUID, String]]
+          assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+            equalTo(Map(uuid1 -> "alpha", uuid2 -> "beta"))
+          )
+        }
+      },
+      test("Map[Int, String] — Int keys parsed from config") {
+        val map = Map(
+          "entries.1" -> "one",
+          "entries.2" -> "two"
+        )
+        val config = deriveConfig[Map[Int, String]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")))(
+          equalTo(Map(1 -> "one", 2 -> "two"))
+        )
+      },
+      test("Invalid UUID key — error message propagation") {
+        val map = Map(
+          "entries.not-a-uuid" -> "value"
+        )
+        val config = deriveConfig[Map[UUID, String]]
+        assertZIO(ConfigProvider.fromMap(map).load(config.nested("entries")).either)(
+          isLeft
+        )
+      },
+      test("Case class containing Map[UUID, CaseClass] — automatic derivation") {
+        check(Gen.uuid, Gen.uuid) { case (uuid1, uuid2) =>
+          val map = Map(
+            s"entries.${uuid1}.x" -> "10",
+            s"entries.${uuid1}.y" -> "hello",
+            s"entries.${uuid2}.x" -> "20",
+            s"entries.${uuid2}.y" -> "world"
+          )
+          val config = deriveConfig[WithUuidMap]
+          assertZIO(ConfigProvider.fromMap(map).load(config))(
+            equalTo(WithUuidMap(Map(
+              uuid1 -> Inner(10, "hello"),
+              uuid2 -> Inner(20, "world")
+            )))
+          )
+        }
+      }
+    )
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                              
                                         
  Adds `ConfigKeyDecoder[K]` typeclass to support `Map[K, V]` where `K` is not `String`, fixing #1381.                                                                                                                                                                                    
                                         
  Previously, `DeriveConfig` only supported `Map[String, V]` via `Config.table`. This adds a `ConfigKeyDecoder` trait that decodes map keys from their string representation, with built-in instances for `String`, `UUID`, `Int`, and `Long`.                                            
                                                                                                                                                                                                                                                                                          
  This is particularly useful for libraries like [neotype](https://github.com/kitlangton/neotype) where wrapper types are commonly used as map keys — see https://github.com/kitlangton/neotype/pull/413 for a concrete use case.

  ## Usage

  ```scala
  // Built-in key types work out of the box
  case class MyConfig(entries: Map[UUID, String])
  val config = deriveConfig[MyConfig]

  // Custom key types need a ConfigKeyDecoder instance
  case class EntryId(value: String)
  given ConfigKeyDecoder[EntryId] = (key: String) => Right(EntryId(key))
  ```

  ## Changes

  - New `ConfigKeyDecoder` trait with built-in instances for `String`, `UUID`, `Int`, `Long`
  - Replaced `Map[String, V]`-only `mapDesc` with generalized `Map[K, V]` version using `ConfigKeyDecoder[K]`
  - Backwards compatible — `Map[String, V]` continues to work as before
  - Supports Scala 2.12, 2.13, and 3

  ## Test plan

  - `Map[String, Int]` — backwards compatibility
  - `Map[UUID, String]` — UUID keys parsed from config
  - `Map[Int, String]` — Int keys parsed from config
  - Invalid key — error propagation
  - Case class containing `Map[UUID, CaseClass]` — automatic derivation