### PR TITLE
Fix the cats module under Scala 3.9

### DIFF
--- a/cats/shared/src/main/scala/zio/config/cats/package.scala
+++ b/cats/shared/src/main/scala/zio/config/cats/package.scala
@@ -40,14 +40,19 @@ package object cats {
   def nonEmptyList[A](path: String)(aDesc: Config[A]): Config[NonEmptyList[A]] =
     nonEmptyList(aDesc).nested(path)
 
-  def nonEmptyMap[A](aDesc: Config[A]): Config[NonEmptyMap[String, A]] =
+  def nonEmptyMap[A](aDesc: Config[A]): Config[NonEmptyMap[String, A]] = {
+    // Kept in implicit scope rather than applied positionally: Scala 3 fills the
+    // implicit itself and then reads the argument list as a key lookup on the map.
+    implicit val ordering: Ordering[String] = Order[String].toOrdering
+
     table(aDesc).mapOrFail(x =>
       NonEmptyMap
-        .fromMap(SortedMap(x.toSeq: _*)(Order[String].toOrdering))
+        .fromMap(SortedMap.empty[String, A] ++ x)
         .fold[Either[Config.Error, NonEmptyMap[String, A]]](Left(Config.Error.InvalidData(message = "map is empty")))(
           v => Right(v)
         )
     )
+  }
 
   def nonEmptyMap[A](path: String)(aDesc: Config[A]): Config[NonEmptyMap[String, A]] =
     nonEmptyMap(aDesc).nested(path)


### PR DESCRIPTION
## Summary

`series/4.x` has been red since #1737 (Scala 3.9.0) merged. Every test job passes; the **`publish` job** fails:

```
[error] (zioConfigCatsJVM / Compile / compileIncremental) Compilation failed
```

## Root cause

`nonEmptyMap` in `cats/shared/src/main/scala/zio/config/cats/package.scala` applied the `Ordering` positionally:

```scala
SortedMap(x.toSeq: _*)(Order[String].toOrdering)
```

Scala 3 fills the implicit `Ordering` itself, and then reads the second argument list as a **key lookup on the resulting map** — hence the otherwise baffling error:

```
[E007] Found:    Ordering[String]
       Required: String
```

The `x: _*` deprecation warning next to it is a red herring; the type error is the failure.

## The fix

Put the `Ordering` in implicit scope instead of applying it positionally, and build the map without a vararg splice.

The obvious fix — `x*` — is **not** available here: this module also publishes `zio-config-cats_2.12` and `_2.13`, and `x*` is not valid Scala 2 syntax. Avoiding varargs entirely keeps one source compiling on all three.

## Why CI didn't catch it

The `testJVM212` / `testJVM213` / `testJVM3x` aliases don't include `zioConfigCats`, so the module is never compiled by the test matrix — only by `ci-release`. That's worth addressing separately; this PR just unbreaks the branch.

## Verification

- `+zioConfigCatsJVM/compile` — clean on 2.12.21, 2.13.18 and 3.9.0
- `+publishLocal` — exit 0, i.e. the exact task the failing release job runs